### PR TITLE
Manually set isSysAdmin boolean when refreshing vcdClient

### DIFF
--- a/pkg/vcdclient/auth.go
+++ b/pkg/vcdclient/auth.go
@@ -34,6 +34,7 @@ type VCDAuthConfig struct {
 	VDC          string `json:"vdc"`
 	Insecure     bool   `json:"insecure"`
 	Token        string `json:"token"`
+	IsSysAdmin   bool   `json:"isSysAdmin,omitempty"` // will be set by GetBearerToken()
 }
 
 func (config *VCDAuthConfig) GetBearerToken() (*govcd.VCDClient, *http.Response, error) {
@@ -63,12 +64,13 @@ func (config *VCDAuthConfig) GetBearerToken() (*govcd.VCDClient, *http.Response,
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to set authorization header: [%v]", err)
 		}
-		vcdClient.Client.IsSysAdmin, err = isAdminUser(vcdClient)
+		config.IsSysAdmin, err = isAdminUser(vcdClient)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to determine if the user is a system administrator: [%v]", err)
 		}
+		vcdClient.Client.IsSysAdmin = config.IsSysAdmin
 
-		klog.Infof("Running CSI as sysadmin [%v]", vcdClient.Client.IsSysAdmin)
+		klog.Infof("Running CPI as sysadmin [%v]", vcdClient.Client.IsSysAdmin)
 		return vcdClient, resp, nil
 	}
 	resp, err = vcdClient.GetAuthResponse(config.User, config.Password, config.UserOrg)

--- a/pkg/vcdclient/auth.go
+++ b/pkg/vcdclient/auth.go
@@ -34,7 +34,7 @@ type VCDAuthConfig struct {
 	VDC          string `json:"vdc"`
 	Insecure     bool   `json:"insecure"`
 	Token        string `json:"token"`
-	IsSysAdmin   bool   `json:"isSysAdmin,omitempty"` // will be set by GetBearerToken()
+	IsSysAdmin   bool   // will be set by GetBearerToken()
 }
 
 func (config *VCDAuthConfig) GetBearerToken() (*govcd.VCDClient, *http.Response, error) {

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -37,6 +37,7 @@ func (client *Client) RefreshBearerToken() error {
 	href := fmt.Sprintf("%s/api", client.vcdAuthConfig.Host)
 	client.vcdClient.Client.APIVersion = VCloudApiVersion
 
+	klog.Infof("Is user sysadmin: [%v]", client.vcdClient.Client.IsSysAdmin)
 	if client.vcdAuthConfig.RefreshToken != "" {
 		// Refresh vcd client using refresh token
 		accessTokenResponse, _, err := client.vcdAuthConfig.getAccessTokenFromRefreshToken(
@@ -51,6 +52,9 @@ func (client *Client) RefreshBearerToken() error {
 		if err != nil {
 			return fmt.Errorf("failed to set authorization header: [%v]", err)
 		}
+		// The previous function call will unset IsSysAdmin boolean for administrator because govcd makes a hard check
+		// on org name. Set the boolean back
+		client.vcdClient.Client.IsSysAdmin = client.vcdAuthConfig.IsSysAdmin
 	} else if client.vcdAuthConfig.User != "" && client.vcdAuthConfig.Password != "" {
 		// Refresh vcd client using username and password
 		resp, err := client.vcdClient.GetAuthResponse(client.vcdAuthConfig.User, client.vcdAuthConfig.Password,


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

When refreshing client using refresh token, isSysadmin boolean for the client should be manually set to true to overwrite the changes made by goVcd during SetToken()

@arunmk @ltimothy7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-director-named-disk-csi-driver/12)
<!-- Reviewable:end -->
