### PR TITLE
[VCDA-2948] Recreate swagger api client with updated access token

### DIFF
--- a/pkg/vcdclient/auth.go
+++ b/pkg/vcdclient/auth.go
@@ -110,7 +110,7 @@ func (config *VCDAuthConfig) GetSwaggerClientFromSecrets() (*govcd.VCDClient, *s
 	swaggerConfig.AddDefaultHeader("Authorization", authHeader)
 	swaggerConfig.HTTPClient = &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: config.Insecure},
 		},
 	}
 

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -76,7 +76,7 @@ func (client *Client) RefreshBearerToken() error {
 			client.vcdAuthConfig.UserOrg, client.vcdAuthConfig.User, href)
 	}
 
-	// Fill up the vdc field again so that clients can reuse legacy API
+	// reset legacy client
 	org, err := client.vcdClient.GetOrgByNameOrId(client.ClusterOrgName)
 	if err != nil {
 		return fmt.Errorf("unable to get vcd organization [%s]: [%v]",
@@ -101,6 +101,7 @@ func (client *Client) RefreshBearerToken() error {
 	}
 	client.apiClient = swaggerClient.NewAPIClient(swaggerConfig)
 
+	klog.Info("successfully refreshed all clients")
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

Recreate swagger client with updated access token after creating a new access token

@arunmk @ltimothy7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-director-named-disk-csi-driver/13)
<!-- Reviewable:end -->
