### PR TITLE
VCDA-3114: Passing user/secret as part of secrets was broken.

### DIFF
--- a/cmd/csi/main.go
+++ b/cmd/csi/main.go
@@ -116,7 +116,7 @@ func runCommand() {
 		}
 
 		waitTime := 10 * time.Second
-		klog.Infof("unable to set authorization in config: [%v]", err)
+		klog.Infof("Unable to set authorization in config: [%v]", err)
 		klog.Infof("Waiting for [%v] before trying again...", waitTime)
 		time.Sleep(waitTime)
 	}

--- a/manifests/csi-controller.yaml
+++ b/manifests/csi-controller.yaml
@@ -136,7 +136,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:0.1.0.latest
+          image: harbor-repo.vmware.com/vcloud/cloud-director-named-disk-csi-driver:main-branch.latest
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-director-named-disk-csi-driver
@@ -150,16 +150,6 @@ spec:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-            - name: VCD_BASIC_AUTH_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: vcloud-basic-auth
-                  key: username
-            - name: VCD_BASIC_AUTH_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: vcloud-basic-auth
-                  key: password
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/manifests/csi-node.yaml
+++ b/manifests/csi-node.yaml
@@ -77,7 +77,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:0.1.0.latest
+          image: harbor-repo.vmware.com/vcloud/cloud-director-named-disk-csi-driver:main-branch.latest
           imagePullPolicy: IfNotPresent
           command :
             - /opt/vcloud/bin/cloud-director-named-disk-csi-driver
@@ -92,16 +92,6 @@ spec:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
-            - name: VCD_BASIC_AUTH_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: vcloud-basic-auth
-                  key: username
-            - name: VCD_BASIC_AUTH_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: vcloud-basic-auth
-                  key: password
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/pkg/vcdclient/auth.go
+++ b/pkg/vcdclient/auth.go
@@ -70,9 +70,10 @@ func (config *VCDAuthConfig) GetBearerToken() (*govcd.VCDClient, *http.Response,
 		}
 		vcdClient.Client.IsSysAdmin = config.IsSysAdmin
 
-		klog.Infof("Running CPI as sysadmin [%v]", vcdClient.Client.IsSysAdmin)
+		klog.Infof("Running as sysadmin [%v]", vcdClient.Client.IsSysAdmin)
 		return vcdClient, resp, nil
 	}
+
 	resp, err = vcdClient.GetAuthResponse(config.User, config.Password, config.UserOrg)
 	if err != nil {
 		return nil, resp, fmt.Errorf("unable to authenticate [%s/%s] for url [%s]: [%+v] : [%v]",
@@ -86,7 +87,7 @@ func (config *VCDAuthConfig) GetVCDClientFromSecrets() (*govcd.VCDClient, error)
 
 	vcdClient, _, err := config.GetBearerToken()
 	if err != nil {
-		return nil, fmt.Errorf("unable to get bearer token from serets: [%v]", err)
+		return nil, fmt.Errorf("unable to get bearer token from secrets: [%v]", err)
 	}
 
 	return vcdClient, nil
@@ -96,7 +97,7 @@ func (config *VCDAuthConfig) GetSwaggerClientFromSecrets() (*govcd.VCDClient, *s
 
 	vcdClient, _, err := config.GetBearerToken()
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to get bearer token from serets: [%v]", err)
+		return nil, nil, fmt.Errorf("unable to get bearer token from secrets: [%v]", err)
 	}
 	var authHeader string
 	if config.RefreshToken == "" {

--- a/release/version
+++ b/release/version
@@ -1,1 +1,1 @@
-0.1.0
+main-branch


### PR DESCRIPTION
They were being passed as secrets and also as VCD config. This
change removes passing as configmap and uses only secrets with
retries.

This change also changes version of main branch to main-branch
so that people can point to the latest unreleased tip.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-director-named-disk-csi-driver/17)
<!-- Reviewable:end -->
