### PR TITLE
Incorporate NO_RDE check into CSI

### DIFF
--- a/pkg/util/defined_entity_util.go
+++ b/pkg/util/defined_entity_util.go
@@ -8,7 +8,7 @@ import (
 const (
 	EntityTypePrefix = "urn:vcloud:type"
 	CAPVCDEntityTypeVendor = "vmware"
-	CAPVCDEntityTypeNss = "capvcd"
+	CAPVCDEntityTypeNss = "capvcdCluster"
 	CAPVCDEntityTypeVersion = "1.0.0"
 
 	NativeClusterEntityTypeVendor = "cse"

--- a/pkg/vcdclient/disks.go
+++ b/pkg/vcdclient/disks.go
@@ -174,7 +174,7 @@ func (client *Client) CreateDisk(diskName string, sizeMB int64, busType string, 
 	// update RDE
 	if client.ClusterID != "" && !strings.HasPrefix(client.ClusterID, NoRdePrefix) {
 		if err = client.addPvToRDE(disk.Id); err != nil {
-			return nil, fmt.Errorf("unable to add PV Id [%s] to RDE: [%v]", disk.Id, err)
+			return nil, NewNoRDEError(fmt.Sprintf("Unable to add PV Id [%s] to RDE; RDE ID is empty or generated", disk.Id))
 		}
 	}
 
@@ -377,7 +377,7 @@ func (client *Client) DeleteDisk(name string) error {
 	// update RDE
 	if client.ClusterID != "" && !strings.HasPrefix(client.ClusterID, NoRdePrefix) {
 		if err = client.removePvFromRDE(disk.Id); err != nil {
-			return fmt.Errorf("unable to remove PV Id [%s] from RDE: [%v]", disk.Id, err)
+			return NewNoRDEError(fmt.Sprintf("unable to remove PV Id [%s] from RDE; RDE ID is empty or generated", disk.Id))
 		}
 	}
 

--- a/pkg/vcdclient/disks.go
+++ b/pkg/vcdclient/disks.go
@@ -24,6 +24,7 @@ import (
 const (
 	VCDBusTypeSCSI           = "6"
 	VCDBusSubTypeVirtualSCSI = "VirtualSCSI"
+	NoRdePrefix = "NO_RDE_"
 )
 
 
@@ -171,7 +172,7 @@ func (client *Client) CreateDisk(diskName string, sizeMB int64, busType string, 
 	klog.Infof("Disk created: [%#v]", disk)
 
 	// update RDE
-	if client.ClusterID != "" {
+	if client.ClusterID != "" && !strings.HasPrefix(client.ClusterID, NoRdePrefix) {
 		if err = client.addPvToRDE(disk.Id); err != nil {
 			return nil, fmt.Errorf("unable to add PV Id [%s] to RDE: [%v]", disk.Id, err)
 		}
@@ -374,7 +375,7 @@ func (client *Client) DeleteDisk(name string) error {
 	}
 
 	// update RDE
-	if client.ClusterID != "" {
+	if client.ClusterID != "" && !strings.HasPrefix(client.ClusterID, NoRdePrefix) {
 		if err = client.removePvFromRDE(disk.Id); err != nil {
 			return fmt.Errorf("unable to remove PV Id [%s] from RDE: [%v]", disk.Id, err)
 		}

--- a/pkg/vcdclient/errors.go
+++ b/pkg/vcdclient/errors.go
@@ -1,0 +1,22 @@
+package vcdclient
+
+import (
+"fmt"
+"runtime/debug"
+)
+
+// NoRDEError is an error used when the InfraID value in the VCDCluster object does not point to a valid RDE in VCD
+type NoRDEError struct {
+	msg string
+}
+
+func (nre *NoRDEError) Error() string {
+	if nre == nil {
+		return fmt.Sprintf("error is unexpectedly nil at stack [%s]", string(debug.Stack()))
+	}
+	return nre.msg
+}
+
+func NewNoRDEError(message string) *NoRDEError {
+	return &NoRDEError{msg: message}
+}


### PR DESCRIPTION
* Change CAPVCD NSS from "capvcd" to "capvcdCluster"
* Add PV to RDE only if RDE doesn't contain NO_RDE prefix

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-director-named-disk-csi-driver/22)
<!-- Reviewable:end -->
