### PR TITLE
[VCDA-3444] Set authentication as system org user before falling back to userOrg

### DIFF
--- a/pkg/vcdclient/auth_system_test.go
+++ b/pkg/vcdclient/auth_system_test.go
@@ -34,62 +34,62 @@ func TestNewVCDAuthConfigFromSecrets(t *testing.T) {
 	err = yaml.Unmarshal(authFileContent, &authDetails)
 	assert.NoError(t, err, "There should be no error parsing auth file content.")
 
+	//vcdClient, err := getTestVCDClient(map[string]interface{}{
+	//	"user": authDetails.Username,
+	//	"secret": authDetails.Password,
+	//	"userOrg": authDetails.UserOrg,
+	//})
+	//assert.NoError(t, err, "Unable to get VCD client")
+	//assert.NotNil(t, vcdClient, "VCD Client should not be nil")
+	//
+	//vcdClient, err = getTestVCDClient(map[string]interface{}{
+	//	"getVdcClient": true,
+	//	"user": authDetails.Username,
+	//	"secret": authDetails.Password,
+	//	"userOrg": authDetails.UserOrg,
+	//})
+	//assert.NoError(t, err, "Unable to get Client with VDC details.")
+	//
+	//vcdClient, err = getTestVCDClient(map[string]interface{}{
+	//	"refreshToken": authDetails.RefreshToken,
+	//	"userOrg": authDetails.UserOrg,
+	//})
+	//assert.NoError(t, err, "Unable to get VCD Client")
+	//assert.NotNil(t, vcdClient, "VCD Client should not be nil")
+	//
+	//vcdClient, err = getTestVCDClient(map[string]interface{}{
+	//	"host": "https://some-random-address",
+	//	"user": authDetails.Username,
+	//	"secret": authDetails.Password,
+	//	"userOrg": authDetails.UserOrg,
+	//})
+	//assert.Error(t, err, "Error should be obtained for url [https://some-random-address]")
+	//
+	//vcdClient, err = getTestVCDClient(map[string]interface{}{
+	//	"oneArm": nil,
+	//	"user": authDetails.Username,
+	//	"secret": authDetails.Password,
+	//	"userOrg": authDetails.UserOrg,
+	//})
+	//assert.NoError(t, err, "There should be no error for missing OneArm")
+	//
+	//vcdClient, err = getTestVCDClient(map[string]interface{}{
+	//	"user": authDetails.SystemUser,
+	//	"secret": authDetails.SystemUserPassword,
+	//	"userOrg": "system",
+	//})
+	//assert.NoError(t, err, "Unable to get VCD client for system administrator")
+	//assert.NotNil(t, vcdClient, "VCD Client should not be nil")
+	//
+	//vcdClient, err = getTestVCDClient(map[string]interface{}{
+	//	"user": authDetails.SystemUser,
+	//	"secret": authDetails.SystemUserPassword,
+	//	"userOrg": "system",
+	//	"network": "",
+	//})
+	//assert.Error(t, err, "Error should be obtained for missing network")
+
 	vcdClient, err := getTestVCDClient(map[string]interface{}{
-		"user": authDetails.Username,
-		"secret": authDetails.Password,
-		"userOrg": authDetails.UserOrg,
-	})
-	assert.NoError(t, err, "Unable to get VCD client")
-	assert.NotNil(t, vcdClient, "VCD Client should not be nil")
-
-	vcdClient, err = getTestVCDClient(map[string]interface{}{
-		"getVdcClient": true,
-		"user": authDetails.Username,
-		"secret": authDetails.Password,
-		"userOrg": authDetails.UserOrg,
-	})
-	assert.NoError(t, err, "Unable to get Client with VDC details.")
-
-	vcdClient, err = getTestVCDClient(map[string]interface{}{
-		"refreshToken": authDetails.RefreshToken,
-		"userOrg": authDetails.UserOrg,
-	})
-	assert.NoError(t, err, "Unable to get VCD Client")
-	assert.NotNil(t, vcdClient, "VCD Client should not be nil")
-
-	vcdClient, err = getTestVCDClient(map[string]interface{}{
-		"host": "https://some-random-address",
-		"user": authDetails.Username,
-		"secret": authDetails.Password,
-		"userOrg": authDetails.UserOrg,
-	})
-	assert.Error(t, err, "Error should be obtained for url [https://some-random-address]")
-
-	vcdClient, err = getTestVCDClient(map[string]interface{}{
-		"oneArm": nil,
-		"user": authDetails.Username,
-		"secret": authDetails.Password,
-		"userOrg": authDetails.UserOrg,
-	})
-	assert.NoError(t, err, "There should be no error for missing OneArm")
-
-	vcdClient, err = getTestVCDClient(map[string]interface{}{
-		"user": authDetails.SystemUser,
-		"secret": authDetails.SystemUserPassword,
-		"userOrg": "system",
-	})
-	assert.NoError(t, err, "Unable to get VCD client for system administrator")
-	assert.NotNil(t, vcdClient, "VCD Client should not be nil")
-
-	vcdClient, err = getTestVCDClient(map[string]interface{}{
-		"user": authDetails.SystemUser,
-		"secret": authDetails.SystemUserPassword,
-		"userOrg": "system",
-		"network": "",
-	})
-	assert.Error(t, err, "Error should be obtained for missing network")
-
-	vcdClient, err = getTestVCDClient(map[string]interface{}{
 		"refreshToken": authDetails.SystemUserRefreshToken,
 		"userOrg": "system",
 	})

--- a/pkg/vcdclient/auth_system_test.go
+++ b/pkg/vcdclient/auth_system_test.go
@@ -34,62 +34,62 @@ func TestNewVCDAuthConfigFromSecrets(t *testing.T) {
 	err = yaml.Unmarshal(authFileContent, &authDetails)
 	assert.NoError(t, err, "There should be no error parsing auth file content.")
 
-	//vcdClient, err := getTestVCDClient(map[string]interface{}{
-	//	"user": authDetails.Username,
-	//	"secret": authDetails.Password,
-	//	"userOrg": authDetails.UserOrg,
-	//})
-	//assert.NoError(t, err, "Unable to get VCD client")
-	//assert.NotNil(t, vcdClient, "VCD Client should not be nil")
-	//
-	//vcdClient, err = getTestVCDClient(map[string]interface{}{
-	//	"getVdcClient": true,
-	//	"user": authDetails.Username,
-	//	"secret": authDetails.Password,
-	//	"userOrg": authDetails.UserOrg,
-	//})
-	//assert.NoError(t, err, "Unable to get Client with VDC details.")
-	//
-	//vcdClient, err = getTestVCDClient(map[string]interface{}{
-	//	"refreshToken": authDetails.RefreshToken,
-	//	"userOrg": authDetails.UserOrg,
-	//})
-	//assert.NoError(t, err, "Unable to get VCD Client")
-	//assert.NotNil(t, vcdClient, "VCD Client should not be nil")
-	//
-	//vcdClient, err = getTestVCDClient(map[string]interface{}{
-	//	"host": "https://some-random-address",
-	//	"user": authDetails.Username,
-	//	"secret": authDetails.Password,
-	//	"userOrg": authDetails.UserOrg,
-	//})
-	//assert.Error(t, err, "Error should be obtained for url [https://some-random-address]")
-	//
-	//vcdClient, err = getTestVCDClient(map[string]interface{}{
-	//	"oneArm": nil,
-	//	"user": authDetails.Username,
-	//	"secret": authDetails.Password,
-	//	"userOrg": authDetails.UserOrg,
-	//})
-	//assert.NoError(t, err, "There should be no error for missing OneArm")
-	//
-	//vcdClient, err = getTestVCDClient(map[string]interface{}{
-	//	"user": authDetails.SystemUser,
-	//	"secret": authDetails.SystemUserPassword,
-	//	"userOrg": "system",
-	//})
-	//assert.NoError(t, err, "Unable to get VCD client for system administrator")
-	//assert.NotNil(t, vcdClient, "VCD Client should not be nil")
-	//
-	//vcdClient, err = getTestVCDClient(map[string]interface{}{
-	//	"user": authDetails.SystemUser,
-	//	"secret": authDetails.SystemUserPassword,
-	//	"userOrg": "system",
-	//	"network": "",
-	//})
-	//assert.Error(t, err, "Error should be obtained for missing network")
-
 	vcdClient, err := getTestVCDClient(map[string]interface{}{
+		"user": authDetails.Username,
+		"secret": authDetails.Password,
+		"userOrg": authDetails.UserOrg,
+	})
+	assert.NoError(t, err, "Unable to get VCD client")
+	assert.NotNil(t, vcdClient, "VCD Client should not be nil")
+
+	vcdClient, err = getTestVCDClient(map[string]interface{}{
+		"getVdcClient": true,
+		"user": authDetails.Username,
+		"secret": authDetails.Password,
+		"userOrg": authDetails.UserOrg,
+	})
+	assert.NoError(t, err, "Unable to get Client with VDC details.")
+
+	vcdClient, err = getTestVCDClient(map[string]interface{}{
+		"refreshToken": authDetails.RefreshToken,
+		"userOrg": authDetails.UserOrg,
+	})
+	assert.NoError(t, err, "Unable to get VCD Client")
+	assert.NotNil(t, vcdClient, "VCD Client should not be nil")
+
+	vcdClient, err = getTestVCDClient(map[string]interface{}{
+		"host": "https://some-random-address",
+		"user": authDetails.Username,
+		"secret": authDetails.Password,
+		"userOrg": authDetails.UserOrg,
+	})
+	assert.Error(t, err, "Error should be obtained for url [https://some-random-address]")
+
+	vcdClient, err = getTestVCDClient(map[string]interface{}{
+		"oneArm": nil,
+		"user": authDetails.Username,
+		"secret": authDetails.Password,
+		"userOrg": authDetails.UserOrg,
+	})
+	assert.NoError(t, err, "There should be no error for missing OneArm")
+
+	vcdClient, err = getTestVCDClient(map[string]interface{}{
+		"user": authDetails.SystemUser,
+		"secret": authDetails.SystemUserPassword,
+		"userOrg": "system",
+	})
+	assert.NoError(t, err, "Unable to get VCD client for system administrator")
+	assert.NotNil(t, vcdClient, "VCD Client should not be nil")
+
+	vcdClient, err = getTestVCDClient(map[string]interface{}{
+		"user": authDetails.SystemUser,
+		"secret": authDetails.SystemUserPassword,
+		"userOrg": "system",
+		"network": "",
+	})
+	assert.Error(t, err, "Error should be obtained for missing network")
+
+	vcdClient, err = getTestVCDClient(map[string]interface{}{
 		"refreshToken": authDetails.SystemUserRefreshToken,
 		"userOrg": "system",
 	})

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -40,10 +40,14 @@ func (client *Client) RefreshBearerToken() error {
 	href := fmt.Sprintf("%s/api", client.vcdAuthConfig.Host)
 	client.vcdClient.Client.APIVersion = VCloudApiVersion
 
-	klog.Infof("Is user sysadmin: [%v]", client.vcdClient.Client.IsSysAdmin)
+	klog.Infof("Is user sysadmin: [%v]", client.vcdAuthConfig.IsSysAdmin)
 	if client.vcdAuthConfig.RefreshToken != "" {
-		// Refresh vcd client using refresh token
-		err := client.vcdClient.SetToken(client.vcdAuthConfig.UserOrg,
+		userOrg := client.vcdAuthConfig.UserOrg
+		if client.vcdAuthConfig.IsSysAdmin {
+			userOrg = "system"
+		}
+		// Refresh vcd client using refresh token as system org user
+		err := client.vcdClient.SetToken(userOrg,
 			govcd.ApiTokenHeader, client.vcdAuthConfig.RefreshToken)
 		if err != nil {
 			return fmt.Errorf("failed to refresh VCD client with refresh token: [%v]", err)

--- a/pkg/vcdclient/common_system_test.go
+++ b/pkg/vcdclient/common_system_test.go
@@ -74,6 +74,8 @@ func getTestVCDClient(inputMap map[string]interface{}) (*Client, error) {
 				insecure = getBoolValStrict(val, true)
 			case "clusterID":
 				cloudConfig.ClusterID = getStrValStrict(val, cloudConfig.ClusterID)
+			case "refreshToken":
+				cloudConfig.VCD.RefreshToken = getStrValStrict(val, cloudConfig.VCD.RefreshToken)
 			case "getVdcClient":
 				getVdcClient = getBoolValStrict(val, false)
 			}


### PR DESCRIPTION
* Address issue with system administrator login using refresh token
* Try authenticating to system org and fall back to user org if it fails
Testing done:
* ran system tests
* Executed CPI as system admin and org admin
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-director-named-disk-csi-driver/34)
<!-- Reviewable:end -->
