### PR TITLE
[VCDA-3472] Update RDE.status.CSI.errors and events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/thecodeteam/gofsutil v0.1.2 // indirect
-	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220529190526-5ecf051bba6a
+	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220601204501-2f50e812a02b
 	github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.3
 	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect

--- a/go.sum
+++ b/go.sum
@@ -406,6 +406,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220529190526-5ecf051bba6a h1:LYEtilvx6Z6EZAx2pyQpvP1xQMRoFTKGFxnU8zM5H4s=
 github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220529190526-5ecf051bba6a/go.mod h1:E7pd/SaAz3M2PGN0T9BbByiwGia4SSJ7+cNZkpE6f60=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220601204501-2f50e812a02b h1:u/U6Uwl5leRiQ37Y2aUNOKfrQtv7knnC0SuO+wWIoOg=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220601204501-2f50e812a02b/go.mod h1:E7pd/SaAz3M2PGN0T9BbByiwGia4SSJ7+cNZkpE6f60=
 github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.3 h1:VJolXzgomaRPrgzSr0EduuUtJIJEf5RdoLbktZFQqIc=
 github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.3/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/csi/controller.go
+++ b/pkg/csi/controller.go
@@ -125,16 +125,16 @@ func (cs *controllerServer) CreateVolume(ctx context.Context,
 		busSubType, "", storageProfile, shareable)
 	if err != nil {
 		if rdeErr := cs.DiskManager.AddToErrorSet("DiskCreateError", diskName, map[string]interface{}{"Detailed Error": err.Error()}); rdeErr != nil {
-			klog.Infof("unable to add error into [CSI.Errors] in RDE [%s], %v", cs.DiskManager.ClusterID, rdeErr)
+			klog.Errorf("unable to add error [%s] into [CSI.Errors] in RDE [%s], %v", "DiskCreateError", cs.DiskManager.ClusterID, rdeErr)
 		}
 		return nil, fmt.Errorf("unable to create disk [%s] with sise [%d]MB: [%v]",
 			diskName, sizeMB, err)
 	}
 	if addEventRdeErr := cs.DiskManager.AddToEventSet("DiskCreateEvent", diskName, map[string]interface{}{"Detailed Info": fmt.Sprintf("Successfully created disk [%s] of size [%d]MB", diskName, sizeMB)}); addEventRdeErr != nil {
-		klog.Infof("unable to add event %s into [CSI.Events] in RDE [%s]", "DiskCreateEvent", cs.DiskManager.ClusterID)
+		klog.Errorf("unable to add event [%s] into [CSI.Events] in RDE [%s]", "DiskCreateEvent", cs.DiskManager.ClusterID)
 	}
 	if removeErrorRdeErr := cs.DiskManager.RemoveFromErrorSet("DiskCreateError", diskName); removeErrorRdeErr != nil {
-		klog.Infof("unable to remove error %s from [CSI.Errors] in RDE [%s]", "DiskCreateError", cs.DiskManager.ClusterID)
+		klog.Errorf("unable to remove error [%s] from [CSI.Errors] in RDE [%s]", "DiskCreateError", cs.DiskManager.ClusterID)
 	}
 	klog.Infof("Successfully created disk [%s] of size [%d]MB", diskName, sizeMB)
 
@@ -180,16 +180,16 @@ func (cs *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 			return &csi.DeleteVolumeResponse{}, nil
 		}
 		if rdeErr := cs.DiskManager.AddToErrorSet("DiskDeleteError", volumeID, map[string]interface{}{"Detailed Error": err.Error()}); rdeErr != nil {
-			klog.Infof("unable to add error into [CSI.Errors] in RDE [%s], %v", cs.DiskManager.ClusterID, rdeErr)
+			klog.Errorf("unable to add error [%s] into [CSI.Errors] in RDE [%s], %v", "DiskDeleteError", cs.DiskManager.ClusterID, rdeErr)
 		}
 		return nil, status.Errorf(codes.Internal, "DeleteVolume failed: [%v]", err)
 	}
 
 	if addEventRdeErr := cs.DiskManager.AddToEventSet("DiskDeleteEvent", "", map[string]interface{}{"Detailed Info": fmt.Sprintf("Volume %s deleted successfully", req.VolumeId)}); addEventRdeErr != nil {
-		klog.Infof("unable to add event %s into [CSI.Events] in RDE [%s]", "DiskDeleteEvent", cs.DiskManager.ClusterID)
+		klog.Errorf("unable to add event [%s] into [CSI.Events] in RDE [%s]", "DiskDeleteEvent", cs.DiskManager.ClusterID)
 	}
 	if removeErrorRdeErr := cs.DiskManager.RemoveFromErrorSet("DiskDeleteError", volumeID); removeErrorRdeErr != nil {
-		klog.Infof("unable to remove error %s from [CSI.Errors] in RDE [%s]", "DiskDeleteError", cs.DiskManager.ClusterID)
+		klog.Errorf("unable to remove error [%s] from [CSI.Errors] in RDE [%s]", "DiskDeleteError", cs.DiskManager.ClusterID)
 	}
 	klog.Infof("Volume %s deleted successfully", req.VolumeId)
 	return &csi.DeleteVolumeResponse{}, nil
@@ -246,12 +246,12 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context,
 	if err != nil {
 		if rdeErr := cs.DiskManager.AddToErrorSet("DiskQueryError", diskName, map[string]interface{}{"Detailed Error": fmt.Errorf("unable query disk [%s]: [%v]",
 			diskName, err)}); rdeErr != nil {
-			klog.Errorf("unable to unable to add error into [CSI.Errors] in RDE [%s], %v", cs.DiskManager.ClusterID, rdeErr)
+			klog.Errorf("unable to unable to add error [%s] into [CSI.Errors] in RDE [%s], %v", "DiskQueryError", cs.DiskManager.ClusterID, rdeErr)
 		}
 		return nil, fmt.Errorf("unable to find disk [%s]: [%v]", diskName, err)
 	}
 	if removeErrorRdeErr := cs.DiskManager.RemoveFromErrorSet("DiskQueryError", diskName); removeErrorRdeErr != nil {
-		klog.Infof("unable to remove error %s from [CSI.Errors] in RDE [%s]", "DiskCreateError", cs.DiskManager.ClusterID)
+		klog.Errorf("unable to remove error [%s] from [CSI.Errors] in RDE [%s]", "DiskCreateError", cs.DiskManager.ClusterID)
 	}
 	klog.Infof("Obtained disk: [%#v]\n", disk)
 
@@ -259,7 +259,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context,
 	err = cs.DiskManager.AttachVolume(vm, disk)
 	if err != nil {
 		if rdeErr := cs.DiskManager.AddToErrorSet("DiskAttachError", diskName, map[string]interface{}{"Detailed Error": err.Error(), "VM Info": nodeID}); rdeErr != nil {
-			klog.Infof("unable to add error into [CSI.Errors] in RDE [%s], %v", cs.DiskManager.ClusterID, rdeErr)
+			klog.Errorf("unable to add error [%s] into [CSI.Errors] in RDE [%s], %v", "DiskAttachError", cs.DiskManager.ClusterID, rdeErr)
 		}
 		if err == govcd.ErrorEntityNotFound {
 			return nil, status.Errorf(codes.NotFound, "could not provision disk [%s] in vcd", diskName)
@@ -267,10 +267,10 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context,
 		return nil, err
 	}
 	if addEventRdeErr := cs.DiskManager.AddToEventSet("DiskAttachEvent", diskName, map[string]interface{}{"Detailed Info": fmt.Sprintf("Successfully attached volume %s to node %s ", diskName, nodeID)}); addEventRdeErr != nil {
-		klog.Infof("unable to add event %s into [CSI.Events] in RDE [%s]", "DiskCreateEvent", cs.DiskManager.ClusterID)
+		klog.Errorf("unable to add event [%s] into [CSI.Events] in RDE [%s]", "DiskCreateEvent", cs.DiskManager.ClusterID)
 	}
 	if removeErrorRdeErr := cs.DiskManager.RemoveFromErrorSet("DiskAttachError", diskName); removeErrorRdeErr != nil {
-		klog.Infof("unable to remove error %s from [CSI.Errors] in RDE [%s]", "DiskAttachError", cs.DiskManager.ClusterID)
+		klog.Errorf("unable to remove error [%s] from [CSI.Errors] in RDE [%s]", "DiskAttachError", cs.DiskManager.ClusterID)
 	}
 	klog.Infof("Successfully attached volume %s to node %s ", diskName, nodeID)
 
@@ -321,7 +321,7 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context,
 	err = cs.DiskManager.DetachVolume(vm, volumeID)
 	if err != nil {
 		if rdeErr := cs.DiskManager.AddToErrorSet("DiskDetachError", volumeID, map[string]interface{}{"Detailed Error": err.Error(), "VM Info": nodeID}); rdeErr != nil {
-			klog.Infof("unable to add error into [CSI.Errors] in RDE [%s], %v", cs.DiskManager.ClusterID, rdeErr)
+			klog.Errorf("unable to add error [%s] into [CSI.Errors] in RDE [%s], %v", "DiskDetachError", cs.DiskManager.ClusterID, rdeErr)
 		}
 		if err == govcd.ErrorEntityNotFound {
 			return nil, status.Errorf(codes.NotFound, "Volume [%s] does not exist", volumeID)
@@ -330,10 +330,10 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context,
 		return nil, err
 	}
 	if addEventRdeErr := cs.DiskManager.AddToEventSet("DiskDetachEvent", volumeID, map[string]interface{}{"Detailed Info": fmt.Sprintf("Successfully detached volume %s from node %s ", volumeID, nodeID)}); addEventRdeErr != nil {
-		klog.Infof("unable to add event %s into [CSI.Events] in RDE [%s]", "DiskDetachEvent", cs.DiskManager.ClusterID)
+		klog.Errorf("unable to add event [%s] into [CSI.Events] in RDE [%s]", "DiskDetachEvent", cs.DiskManager.ClusterID)
 	}
 	if removeErrorRdeErr := cs.DiskManager.RemoveFromErrorSet("DiskDetachError", volumeID); removeErrorRdeErr != nil {
-		klog.Infof("unable to remove error %s from [CSI.Errors] in RDE [%s]", "DiskDetachError", cs.DiskManager.ClusterID)
+		klog.Errorf("unable to remove error [%s] from [CSI.Errors] in RDE [%s]", "DiskDetachError", cs.DiskManager.ClusterID)
 	}
 	klog.Infof("Volume [%s] unpublished successfully", volumeID)
 

--- a/pkg/csi/driver.go
+++ b/pkg/csi/driver.go
@@ -124,9 +124,12 @@ func (d *VCDDriver) Setup(diskManager *vcdcsiclient.DiskManager, VAppName string
 	if vcdsdk.IsCAPVCDEntityType(diskManager.ClusterID) {
 		err := diskManager.UpgradeRDEPersistentVolumes()
 		if err != nil {
-			//Todo update csi.errors
+			if rdeErr := diskManager.AddToErrorSet("RdeUpgradeError", "", map[string]interface{}{"Detailed Error": err.Error()}); rdeErr != nil {
+				klog.Infof("unable to add error into [CSI.Errors] in RDE [%s], %v", diskManager.ClusterID, rdeErr)
+			}
 			return fmt.Errorf("CSI section upgrade failed when CAPVCD RDE is present, [%v]", err)
 		}
+		diskManager.AddToEventSet("RdeUpgradeEvent", "", nil)
 	}
 	return nil
 }

--- a/pkg/csi/driver.go
+++ b/pkg/csi/driver.go
@@ -125,11 +125,16 @@ func (d *VCDDriver) Setup(diskManager *vcdcsiclient.DiskManager, VAppName string
 		err := diskManager.UpgradeRDEPersistentVolumes()
 		if err != nil {
 			if rdeErr := diskManager.AddToErrorSet("RdeUpgradeError", "", map[string]interface{}{"Detailed Error": err.Error()}); rdeErr != nil {
-				klog.Infof("unable to add error into [CSI.Errors] in RDE [%s], %v", diskManager.ClusterID, rdeErr)
+				klog.Errorf("unable to add error [%s] into [CSI.Errors] in RDE [%s], %v", "RdeUpgradeError", diskManager.ClusterID, rdeErr)
 			}
 			return fmt.Errorf("CSI section upgrade failed when CAPVCD RDE is present, [%v]", err)
 		}
-		diskManager.AddToEventSet("RdeUpgradeEvent", "", nil)
+		if addEventRdeErr := diskManager.AddToEventSet("RdeUpgradeEvent", "", nil); addEventRdeErr != nil {
+			klog.Errorf("unable to add event [%s] into [CSI.Events] in RDE [%s]", "RdeUpgradeEvent", diskManager.ClusterID)
+		}
+		if removeErrorRdeErr := diskManager.RemoveFromErrorSet("RdeUpgradeError", ""); removeErrorRdeErr != nil {
+			klog.Errorf("unable to remove error [%s] from [CSI.Errors] in RDE [%s]", "RdeUpgradeError", diskManager.ClusterID)
+		}
 	}
 	return nil
 }

--- a/pkg/util/defined_entity_util.go
+++ b/pkg/util/defined_entity_util.go
@@ -13,7 +13,7 @@ const (
 	ResourcePersistentVolume = "named-disk"
 	CSIName                  = "cloud-director-named-disk-csi-driver"
 	OldPersistentVolumeKey   = "persistentVolumes"
-	PVDetailsNum             = 2
+	DefaultWindowSize        = 10
 )
 
 func GetPVsFromRDE(rde *swaggerClient.DefinedEntity) ([]string, error) {

--- a/pkg/vcdcsiclient/disks.go
+++ b/pkg/vcdcsiclient/disks.go
@@ -117,13 +117,13 @@ func (diskManager *DiskManager) CreateDisk(diskName string, sizeMB int64, busTyp
 	if err != nil && err != govcd.ErrorEntityNotFound {
 		if rdeErr := diskManager.AddToErrorSet("DiskQueryError", diskName, map[string]interface{}{"Detailed Error": fmt.Errorf("unable query disk [%s]: [%v]",
 			diskName, err)}); rdeErr != nil {
-			klog.Errorf("unable to unable to add error into [CSI.Errors] in RDE [%s], %v", diskManager.ClusterID, rdeErr)
+			klog.Errorf("unable to unable to add error [%s] into [CSI.Errors] in RDE [%s], %v", "DiskQueryError", diskManager.ClusterID, rdeErr)
 		}
 		return nil, fmt.Errorf("unable to check if disk [%s] already exists: [%v]",
 			diskName, err)
 	}
 	if removeErrorRdeErr := diskManager.RemoveFromErrorSet("DiskQueryError", diskName); removeErrorRdeErr != nil {
-		klog.Infof("unable to remove error %s from [CSI.Errors] in RDE [%s]", "DiskCreateError", diskManager.ClusterID)
+		klog.Errorf("unable to remove error [%s] from [CSI.Errors] in RDE [%s]", "DiskCreateError", diskManager.ClusterID)
 	}
 
 	if disk != nil {
@@ -713,7 +713,7 @@ func (diskManager *DiskManager) UpgradeRDEPersistentVolumes() error {
 				AdditionalDetails: nil,
 			}
 			if rdeErr := rdeManager.AddToErrorSet(context.Background(), vcdsdk.ComponentCSI, rdeIncorrectFormatError, util.DefaultWindowSize); rdeErr != nil {
-				klog.Infof("unable to add error into [CSI.Errors] in RDE [%s], %v", diskManager.ClusterID, rdeErr)
+				klog.Errorf("unable to add error [%s] into [CSI.Errors] in RDE [%s], %v", "RdeIncorrectFormatError", diskManager.ClusterID, rdeErr)
 			}
 			klog.Errorf("content under section ['status'] has incorrect format in the RDE [%s]: skipping upgrade of CSI section in RDE status",
 				diskManager.ClusterID)
@@ -729,7 +729,7 @@ func (diskManager *DiskManager) UpgradeRDEPersistentVolumes() error {
 				AdditionalDetails: map[string]interface{}{"Detailed Error": err.Error()},
 			}
 			if rdeErr := rdeManager.AddToErrorSet(context.Background(), vcdsdk.ComponentCSI, rdeIncorrectFormatError, util.DefaultWindowSize); rdeErr != nil {
-				klog.Infof("unable to add error into [CSI.Errors] in RDE [%s], %v", diskManager.ClusterID, rdeErr)
+				klog.Errorf("unable to add error [%s] into [CSI.Errors] in RDE [%s], %v", "RdeIncorrectFormatError", diskManager.ClusterID, rdeErr)
 			}
 			klog.Errorf("failed to continue RDE upgrade for RDE with ID [%s]: [%v]",
 				diskManager.ClusterID, err)
@@ -772,7 +772,7 @@ func (diskManager *DiskManager) UpgradeRDEPersistentVolumes() error {
 					AdditionalDetails: nil,
 				}
 				if rdeErr := rdeManager.AddToErrorSet(context.Background(), vcdsdk.ComponentCSI, rdeIncorrectFormatError, util.DefaultWindowSize); rdeErr != nil {
-					klog.Infof("unable to add error into [CSI.Errors] in RDE [%s], %v", diskManager.ClusterID, rdeErr)
+					klog.Errorf("unable to add error [%s] into [CSI.Errors] in RDE [%s], %v", "RdeIncorrectFormatError", diskManager.ClusterID, rdeErr)
 				}
 				klog.Errorf("error occurred when updating VCDResource set of CSI status in RDE [%s]: [%v]; skipping upgrade of CSI section in RDE status", diskManager.ClusterID, err)
 				return nil
@@ -786,7 +786,7 @@ func (diskManager *DiskManager) UpgradeRDEPersistentVolumes() error {
 
 		for _, diskQueryError := range diskQueryErrorList {
 			if rdeErr := rdeManager.AddToErrorSet(context.Background(), vcdsdk.ComponentCSI, diskQueryError, util.DefaultWindowSize); rdeErr != nil {
-				klog.Infof("unable to add error into [CSI.Errors] in RDE [%s], %v", diskManager.ClusterID, rdeErr)
+				klog.Errorf("unable to add error [%s]into [CSI.Errors] in RDE [%s], %v", diskQueryError.Name, diskManager.ClusterID, rdeErr)
 			}
 		}
 		if httpResponse != nil {

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/util/allocatedresources.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/util/allocatedresources.go
@@ -6,7 +6,7 @@ import (
 )
 
 type AllocatedResourcesMap struct {
-	RWLock sync.RWMutex
+	RWLock             sync.RWMutex
 	allocatedResources map[string][]swaggerClient.EntityReference
 }
 
@@ -43,7 +43,7 @@ func (ar *AllocatedResourcesMap) Insert(key string, value *swaggerClient.EntityR
 	return
 }
 
-func (ar *AllocatedResourcesMap) Get(key string) ([]swaggerClient.EntityReference) {
+func (ar *AllocatedResourcesMap) Get(key string) []swaggerClient.EntityReference {
 	ar.RWLock.RLock()
 	defer ar.RWLock.RUnlock()
 
@@ -54,4 +54,3 @@ func (ar *AllocatedResourcesMap) Get(key string) ([]swaggerClient.EntityReferenc
 
 	return values
 }
-

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/util/set.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/util/set.go
@@ -8,7 +8,7 @@ package util
 import "sync"
 
 type Set struct {
-	lock sync.RWMutex
+	lock     sync.RWMutex
 	elements map[string]bool
 }
 
@@ -33,7 +33,7 @@ func (s Set) GetElements() []string {
 	idx := 0
 	for key, _ := range s.elements {
 		elementList[idx] = key
-		idx ++
+		idx++
 	}
 
 	return elementList

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/defined_entity.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/defined_entity.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/klog"
 	"net/http"
 	"strings"
+	"time"
 )
 
 const (
@@ -16,6 +17,8 @@ const (
 	MaxRDEUpdateRetries = 10
 
 	ComponentStatusFieldVCDResourceSet = "vcdResourceSet"
+	ComponentStatusFieldErrorSet       = "errorSet"
+	ComponentStatusFieldEventSet       = "eventSet"
 
 	ComponentCPI    = "cpi"
 	ComponentCSI    = "csi"
@@ -41,8 +44,24 @@ type VCDResource struct {
 	AdditionalDetails map[string]interface{} `json:"additionalDetails,omitempty"`
 }
 
+type BackendError struct {
+	Name              string                 `json:"name,omitempty"`
+	OccurredAt        time.Time              `json:"occurredAt, omitempty"`
+	VcdResourceId     string                 `json:"vcdResourceId, omitempty"`
+	AdditionalDetails map[string]interface{} `json:"additionalDetails,omitempty"`
+}
+
+type BackendEvent struct {
+	Name              string                 `json:"name,omitempty"`
+	OccurredAt        time.Time              `json:"occurredAt,omitempty"`
+	VcdResourceId     string                 `json:"vcdResourceId,omitempty"`
+	AdditionalDetails map[string]interface{} `json:"additionalDetails,omitempty"`
+}
+
 type ComponentStatus struct {
-	VCDResourceSet []VCDResource `json:"vcdResourceSet,omitempty"`
+	VCDResourceSet []VCDResource  `json:"vcdResourceSet,omitempty"`
+	ErrorSet       []BackendError `json:"errorSet,omitempty"`
+	EventSet       []BackendEvent `json:"eventSet,omitempty"`
 }
 
 type RDEManager struct {
@@ -121,7 +140,7 @@ func addToVCDResourceSet(component string, componentName string, componentVersio
 
 	componentStatus, err := convertMapToComponentStatus(componentMap)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert component status map to ")
+		return nil, fmt.Errorf("failed to convert component status map to component status object")
 	}
 
 	if componentStatus.VCDResourceSet == nil || len(componentStatus.VCDResourceSet) == 0 {
@@ -149,12 +168,358 @@ func addToVCDResourceSet(component string, componentName string, componentVersio
 	return statusMap, nil
 }
 
+/*
+AddToErrorSet function takes BackendError as an input and adds it to the "errorSet" of the specified "componentSectionName" in the RDE status.
+It caps the size of the "errorSet" in the specified "componentSectionName" to the "rollingWindowSize", by removing the oldest entries.
+
+It raises errors on below conditions. It is caller/component's responsibility to distinguish the errors as either hard (or) soft failures.
+ - If rdeId is not valid or empty.
+ - If rde.entity.status section is missing
+ - If rde is not of type capvcdCluster
+ - On any failures while updating the RDE.
+
+Below is the sample structure of the RDE this function operates on. <componentSectionName> could be "csi", "cpi", "capvcd", "vkp"
+status:
+  <componentSectionName>:
+     errorSet:
+       - <newError>
+*/
+func (rdeManager *RDEManager) AddToErrorSet(ctx context.Context, componentSectionName string, newError BackendError, rollingWindowSize int) error {
+	if rdeManager.ClusterID == "" || strings.HasPrefix(rdeManager.ClusterID, NoRdePrefix) {
+		// Indicates that the RDE ID is either empty or it was auto-generated.
+		klog.Infof("ClusterID [%s] is empty or generated, hence cannot add errors [%v] to RDE",
+			rdeManager.ClusterID, newError)
+		return nil
+	}
+	for i := MaxRDEUpdateRetries; i > 1; i-- {
+		rde, resp, etag, err := rdeManager.Client.APIClient.DefinedEntityApi.GetDefinedEntity(ctx, rdeManager.ClusterID)
+		if resp != nil && resp.StatusCode != http.StatusOK {
+			var responseMessageBytes []byte
+			if gsErr, ok := err.(swaggerClient.GenericSwaggerError); ok {
+				responseMessageBytes = gsErr.Body()
+			}
+			return fmt.Errorf(
+				"failed to get RDE [%s] when adding error to the errorSet of [%s] ; expected http response [%v], obtained [%v]: resp: [%#v]: [%v]",
+				rdeManager.ClusterID, componentSectionName, http.StatusOK, resp.StatusCode, string(responseMessageBytes), err)
+		} else if err != nil {
+			return fmt.Errorf("error retrieving the RDE [%s]: [%v], while adding to errorSet", rdeManager.ClusterID, err)
+		}
+		// Only entity of type capvcdCluster should be updated.
+		if !IsCAPVCDEntityType(rde.EntityType) {
+			nonCapvcdEntityError := NonCAPVCDEntityError{
+				EntityTypeID: rde.EntityType,
+			}
+			return nonCapvcdEntityError
+		}
+
+		statusIf, ok := rde.Entity["status"]
+		if !ok {
+			return fmt.Errorf("missing RDE status section in [%s], while adding error [%v] to the errorSet", rdeManager.ClusterID, newError)
+		}
+		statusMap, ok := statusIf.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("failed to convert RDE status [%s] to map[string]interface{}, while adding error [%s] to the errorSet", rdeManager.ClusterID, newError)
+		}
+
+		// update the statusMap (in memory) with the new Error in the specified componentSection
+		updatedStatusMap, err := rdeManager.updateComponentMapWithNewError(componentSectionName, statusMap, newError, rollingWindowSize)
+		if err != nil {
+			return fmt.Errorf("error occurred when updating error set of [%s] status in RDE [%s]: [%v]", componentSectionName, rdeManager.ClusterID, err)
+		}
+		rde.Entity["status"] = updatedStatusMap
+
+		// persist the updated statusMap to VCD
+		_, resp, err = rdeManager.Client.APIClient.DefinedEntityApi.UpdateDefinedEntity(ctx, rde, etag, rdeManager.ClusterID, nil)
+		if resp != nil {
+			if resp.StatusCode == http.StatusPreconditionFailed {
+				klog.Errorf("wrong etag while adding newError [%v] in RDE [%s]. Retry attempts remaining: [%d]", newError, rdeManager.ClusterID, i-1)
+				continue
+			} else if resp.StatusCode != http.StatusOK {
+				var responseMessageBytes []byte
+				if gsErr, ok := err.(swaggerClient.GenericSwaggerError); ok {
+					responseMessageBytes = gsErr.Body()
+				}
+				return fmt.Errorf(
+					"failed to add newError [%v] in componentSectionName [%s] of RDE [%s]; expected http response [%v], obtained [%v]: resp: [%#v]: [%v]",
+					newError, componentSectionName, rdeManager.ClusterID, http.StatusOK, resp.StatusCode, string(responseMessageBytes), err)
+			}
+			// resp.StatusCode is http.StatusOK
+			klog.Infof("successfully added newError [%v] in componentSectionName [%s] of RDE [%s]",
+				newError, componentSectionName, rdeManager.ClusterID)
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("error while updating the RDE [%s]: [%v]", rdeManager.ClusterID, err)
+		} else {
+			return fmt.Errorf("invalid response obtained when updating newError [%v] of componentSectionName [%s] in RDE [%s]", newError, componentSectionName, rdeManager.ClusterID)
+		}
+	}
+
+	return nil
+}
+
+/*
+RemoveErrorByNameOrIdFromErrorSet Given a name (and/or) vcdResourceId of the error, it removes all the matching entries from the errorset of the
+specified component section in the RDE.status.
+
+Note that vcdResourceId parameter is optional. If a non-empty vcdResourceId is passed, it tries to match both the errorName and vcdResourceId
+
+Below is the RDE portion this function operates on
+RDE.entity
+ status
+   <componentSectionName> //capvcd, csi, cpi, vkp
+       errorSet
+          <controlPlaneError>
+          <cloudInitError>
+*/
+func (rdeManager *RDEManager) RemoveErrorByNameOrIdFromErrorSet(ctx context.Context, componentSectionName string, errorName string, vcdResourceId string) error {
+	if rdeManager.ClusterID == "" || strings.HasPrefix(rdeManager.ClusterID, NoRdePrefix) {
+		// Indicates that the RDE ID is either empty or it was auto-generated.
+		klog.Infof("ClusterID [%s] is empty or generated, hence cannot remove any errors of name [%s] from RDE",
+			rdeManager.ClusterID, errorName)
+		return nil
+	}
+	if errorName == "" {
+		return fmt.Errorf("errorName cannot be empty, while removing error from the errorSet of [%s]", rdeManager.ClusterID)
+	}
+	for i := MaxRDEUpdateRetries; i > 1; i-- {
+		rde, resp, etag, err := rdeManager.Client.APIClient.DefinedEntityApi.GetDefinedEntity(ctx, rdeManager.ClusterID)
+		if resp != nil && resp.StatusCode != http.StatusOK {
+			var responseMessageBytes []byte
+			if gsErr, ok := err.(swaggerClient.GenericSwaggerError); ok {
+				responseMessageBytes = gsErr.Body()
+			}
+			return fmt.Errorf(
+				"failed to get RDE [%s] when removing error from the errorSet of [%s] ; expected http response [%v], obtained [%v]: resp: [%#v]: [%v]",
+				rdeManager.ClusterID, componentSectionName, http.StatusOK, resp.StatusCode, string(responseMessageBytes), err)
+		} else if err != nil {
+			return fmt.Errorf("error retrieving the RDE [%s]: [%v], while removing error [%s] from errorSet", rdeManager.ClusterID, err, errorName)
+		}
+		// Only entity of type capvcdCluster should be updated.
+		if !IsCAPVCDEntityType(rde.EntityType) {
+			nonCapvcdEntityError := NonCAPVCDEntityError{
+				EntityTypeID: rde.EntityType,
+			}
+			return nonCapvcdEntityError
+		}
+
+		statusIf, ok := rde.Entity["status"]
+		if !ok {
+			return fmt.Errorf("missing RDE status section in [%s], while removing error [%s] from the errorSet", rdeManager.ClusterID, errorName)
+		}
+		statusMap, ok := statusIf.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("failed to convert RDE status [%s] to map[string]interface{}, while removing error [%s] from the errorSet", rdeManager.ClusterID, errorName)
+		}
+
+		// update the statusMap (in memory) with the new Error in the specified componentSection
+		updatedStatusMap, matchingErrorsRemoved, err := rdeManager.removeErrorsfromComponentMap(componentSectionName, statusMap, errorName, vcdResourceId)
+		if err != nil {
+			return fmt.Errorf("error occurred when removing error [%s] from the error set of [%s] status in RDE [%s]: [%v]", errorName, componentSectionName, rdeManager.ClusterID, err)
+		}
+		if !matchingErrorsRemoved {
+			klog.V(3).Infof("No matching errors found and removed from the existing error set of [%s] of RDE [%s]", componentSectionName, rdeManager.ClusterID)
+			return nil
+		}
+		rde.Entity["status"] = updatedStatusMap
+
+		// persist the updated statusMap to VCD
+		_, resp, err = rdeManager.Client.APIClient.DefinedEntityApi.UpdateDefinedEntity(ctx, rde, etag, rdeManager.ClusterID, nil)
+		if resp != nil {
+			if resp.StatusCode == http.StatusPreconditionFailed {
+				klog.Errorf("wrong etag while removing error(s) of name [%s] in RDE [%s]. Retry attempts remaining: [%d]", errorName, rdeManager.ClusterID, i-1)
+				continue
+			} else if resp.StatusCode != http.StatusOK {
+				var responseMessageBytes []byte
+				if gsErr, ok := err.(swaggerClient.GenericSwaggerError); ok {
+					responseMessageBytes = gsErr.Body()
+				}
+				return fmt.Errorf(
+					"failed to remove errors [%s] in componentSectionName [%s] of RDE [%s]; expected http response [%v], obtained [%v]: resp: [%#v]: [%v]",
+					errorName, componentSectionName, rdeManager.ClusterID, http.StatusOK, resp.StatusCode, string(responseMessageBytes), err)
+			}
+			// resp.StatusCode is http.StatusOK
+			klog.Infof("successfully removed errors of type [%s] in componentSectionName [%s] of RDE [%s]",
+				errorName, componentSectionName, rdeManager.ClusterID)
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("error while updating the RDE [%s]: [%v]", rdeManager.ClusterID, err)
+		} else {
+			return fmt.Errorf("invalid response obtained when removing errors of type [%s] of componentSectionName [%s] in RDE [%s]", errorName, componentSectionName, rdeManager.ClusterID)
+		}
+	}
+
+	return nil
+}
+
+/*
+function updateComponentMapWithNewEvent updates the local (in memory) rde status map with the specified new event.
+It also ensures the length of the "eventSet" is capped at the specified "rollingWindowSize" by removing the old entries.
+
+This function does NOT persist the data into VCD.
+*/
+func (rdeManager *RDEManager) updateComponentMapWithNewEvent(componentName string, statusMap map[string]interface{}, newEvent BackendEvent, rollingWindowSize int) (map[string]interface{}, error) {
+	// get the component info from the status
+	componentIf, ok := statusMap[componentName]
+	if !ok {
+		// component map not found
+		statusMap[componentName] = map[string]interface{}{
+			"name":     rdeManager.StatusComponentName,
+			"version":  rdeManager.StatusComponentVersion,
+			"eventSet": []BackendEvent{newEvent},
+		}
+		klog.Infof("created component map [%#v] since the component was not found in the status map", statusMap[componentName])
+		return statusMap, nil
+	}
+	componentMap, ok := componentIf.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("failed to convert the status belonging to component [%s] to map[string]interface{}", componentName)
+	}
+	componentStatus, err := convertMapToComponentStatus(componentMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert component status [%s] map to Component object", componentName)
+	}
+
+	newSize := len(componentStatus.EventSet) + 1
+	componentStatus.EventSet = append(componentStatus.EventSet, newEvent)
+	if newSize > rollingWindowSize {
+		componentStatus.EventSet = componentStatus.EventSet[1:]
+	}
+	componentMap[ComponentStatusFieldEventSet] = componentStatus.EventSet
+	return statusMap, nil
+}
+
+/*
+function updateComponentMapWithNewError updates the local (in memory) rde status map with the specified new error.
+It also ensures the length of the "errorSet" is capped at the specified "rollingWindowSize" by removing the old entries.
+This function does NOT persist the data into VCD.
+*/
+func (rdeManager *RDEManager) updateComponentMapWithNewError(componentRdeSectionName string, statusMap map[string]interface{}, newError BackendError, rollingWindowSize int) (map[string]interface{}, error) {
+	// get the component info from the status
+	componentIf, ok := statusMap[componentRdeSectionName]
+	if !ok {
+		// component map not found
+		statusMap[componentRdeSectionName] = map[string]interface{}{
+			"name":     rdeManager.StatusComponentName,
+			"version":  rdeManager.StatusComponentVersion,
+			"errorSet": []BackendError{newError},
+		}
+		klog.Infof("created component map [%#v] since the component was not found in the status map", statusMap[componentRdeSectionName])
+		return statusMap, nil
+	}
+	componentMap, ok := componentIf.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("failed to convert the status belonging to component [%s] to map[string]interface{}", componentRdeSectionName)
+	}
+	componentStatus, err := convertMapToComponentStatus(componentMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert component status map [%s] to Component object", componentRdeSectionName)
+	}
+
+	newSize := len(componentStatus.ErrorSet) + 1
+	componentStatus.ErrorSet = append(componentStatus.ErrorSet, newError)
+	if newSize > rollingWindowSize {
+		componentStatus.ErrorSet = componentStatus.ErrorSet[1:]
+	}
+	componentMap[ComponentStatusFieldErrorSet] = componentStatus.ErrorSet
+	return statusMap, nil
+}
+
+/*
+AddToEventSet function takes BackendEvent as an input and adds it to the "eventSet" of the specified "componentSectionName" in the RDE status.
+It caps the size of the "eventSet" in the specified "componentSectionName" to the "rollingWindowSize" by removing the oldest entries.
+
+It raises errors on below conditions. It is caller/component's responsibility to distinguish the errors as either hard (or) soft failures.
+ - If rdeId is not valid or empty.
+ - If rde.entity.status section is missing
+ - If rde is not of type capvcdCluster
+ - On any failures while updating the RDE.
+
+Below is the sample structure of the RDE this function operates on.
+status:
+  <componentSectionName>:
+     eventSet:
+       - <newEvent>
+       - existingEvent
+*/
+func (rdeManager *RDEManager) AddToEventSet(ctx context.Context, componentSectionName string, newEvent BackendEvent, rollingWindowSize int) error {
+	if rdeManager.ClusterID == "" || strings.HasPrefix(rdeManager.ClusterID, NoRdePrefix) {
+		// Indicates that the RDE ID is either empty or it was auto-generated.
+		klog.Infof("ClusterID [%s] is empty or generated, hence cannot add events [%#v] to RDE",
+			rdeManager.ClusterID, newEvent)
+		return nil
+	}
+	for i := MaxRDEUpdateRetries; i > 1; i-- {
+		rde, resp, etag, err := rdeManager.Client.APIClient.DefinedEntityApi.GetDefinedEntity(ctx, rdeManager.ClusterID)
+		if resp != nil && resp.StatusCode != http.StatusOK {
+			var responseMessageBytes []byte
+			if gsErr, ok := err.(swaggerClient.GenericSwaggerError); ok {
+				responseMessageBytes = gsErr.Body()
+			}
+			return fmt.Errorf(
+				"failed to get RDE [%s] when adding event to the eventSet of [%s] ; expected http response [%v], obtained [%v]: resp: [%#v]: [%v]",
+				rdeManager.ClusterID, componentSectionName, http.StatusOK, resp.StatusCode, string(responseMessageBytes), err)
+		} else if err != nil {
+			return fmt.Errorf("error retrieving the RDE [%s]: [%v], while adding to eventSet", rdeManager.ClusterID, err)
+		}
+		// Only entity of type capvcdCluster should be updated.
+		if !IsCAPVCDEntityType(rde.EntityType) {
+			nonCapvcdEntityError := NonCAPVCDEntityError{
+				EntityTypeID: rde.EntityType,
+			}
+			return nonCapvcdEntityError
+		}
+
+		statusIf, ok := rde.Entity["status"]
+		if !ok {
+			return fmt.Errorf("missing RDE status section in [%s], while adding event [%s] to the eventSet", rdeManager.ClusterID, newEvent)
+		}
+		statusMap, ok := statusIf.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("failed to convert RDE status [%s] to map[string]interface{}, while adding event [%#v] to the eventSet ", rdeManager.ClusterID, newEvent)
+		}
+
+		// update the statusMap (in memory) with the new Event in the specified componentSection
+		updatedStatusMap, err := rdeManager.updateComponentMapWithNewEvent(componentSectionName, statusMap, newEvent, rollingWindowSize)
+		if err != nil {
+			return fmt.Errorf("error occurred while updating event set of [%s] in RDE [%s]: [%v]", componentSectionName, rdeManager.ClusterID, err)
+		}
+		rde.Entity["status"] = updatedStatusMap
+
+		// persist the updated statusMap to VCD
+		_, resp, err = rdeManager.Client.APIClient.DefinedEntityApi.UpdateDefinedEntity(ctx, rde, etag, rdeManager.ClusterID, nil)
+		if resp != nil {
+			if resp.StatusCode == http.StatusPreconditionFailed {
+				klog.Errorf("wrong etag while adding newEvent [%#v] in RDE [%s]. Retry attempts remaining: [%d]", newEvent, rdeManager.ClusterID, i-1)
+				continue
+			} else if resp.StatusCode != http.StatusOK {
+				var responseMessageBytes []byte
+				if gsErr, ok := err.(swaggerClient.GenericSwaggerError); ok {
+					responseMessageBytes = gsErr.Body()
+				}
+				return fmt.Errorf(
+					"failed to add newEvent [%#v] in componentSectionName [%s] of RDE [%s]; expected http response [%v], obtained [%v]: resp: [%#v]: [%v]",
+					newEvent, componentSectionName, rdeManager.ClusterID, http.StatusOK, resp.StatusCode, string(responseMessageBytes), err)
+			}
+			// resp.StatusCode is http.StatusOK
+			klog.Infof("successfully added newEvent [%v] in componentSectionName [%s] of RDE [%s]",
+				newEvent, componentSectionName, rdeManager.ClusterID)
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("error while updating the RDE [%s]: [%v]", rdeManager.ClusterID, err)
+		} else {
+			return fmt.Errorf("invalid response obtained when updating newEvent [%#v] of componentSectionName [%s] in RDE [%s]", newEvent, componentSectionName, rdeManager.ClusterID)
+		}
+	}
+
+	return nil
+}
+
 // AddToVCDResourceSet adds a VCDResource to the VCDResourceSet of the component in the RDE
 func (rdeManager *RDEManager) AddToVCDResourceSet(ctx context.Context, component string, resourceType string,
 	resourceName string, resourceId string, additionalDetails map[string]interface{}) error {
 	if rdeManager.ClusterID == "" || strings.HasPrefix(rdeManager.ClusterID, NoRdePrefix) {
 		// Indicates that the RDE ID is either empty or it was auto-generated.
-		klog.Infof("ClusterID [%s] is empty or generated, hence not adding VCDResource [%s:%s] from RDE",
+		klog.Infof("ClusterID [%s] is empty or generated, hence not adding VCDResource [%s:%s] to RDE",
 			rdeManager.ClusterID, resourceType, resourceId)
 		return nil
 	}
@@ -166,10 +531,10 @@ func (rdeManager *RDEManager) AddToVCDResourceSet(ctx context.Context, component
 				responseMessageBytes = gsErr.Body()
 			}
 			return fmt.Errorf(
-				"failed to get RDE [%s] when adding resourse to VCD resource set ; expected http response [%v], obtained [%v]: resp: [%#v]: [%v]",
+				"failed to get RDE [%s] when adding resource to VCD resource set ; expected http response [%v], obtained [%v]: resp: [%#v]: [%v]",
 				rdeManager.ClusterID, http.StatusOK, resp.StatusCode, string(responseMessageBytes), err)
 		} else if err != nil {
-			return fmt.Errorf("error while updating the RDE [%s]: [%v]", rdeManager.ClusterID, err)
+			return fmt.Errorf("error retrieving the RDE [%s]: [%v], while adding to vcdResourceSet", rdeManager.ClusterID, err)
 		}
 
 		// Only entity of type capvcdCluster should be updated.
@@ -346,4 +711,40 @@ func (rdeManager *RDEManager) RemoveFromVCDResourceSet(ctx context.Context, comp
 		}
 	}
 	return nil
+}
+
+/*
+function removeErrorsfromComponentMap updates the local (in memory) rde status map with the specified error(s) removed.
+This function does NOT persist the data into VCD.
+*/
+func (rdeManager *RDEManager) removeErrorsfromComponentMap(componentRdeSectionName string, statusMap map[string]interface{}, errorName string, vcdResourceId string) (map[string]interface{}, bool, error) {
+	// get the component info from the status
+	componentIf, ok := statusMap[componentRdeSectionName]
+	if !ok {
+		klog.Infof("missing component [%s] from the rde status, hence skipping removing errors", componentRdeSectionName)
+		return nil, false, nil
+	}
+	componentMap, ok := componentIf.(map[string]interface{})
+	if !ok {
+		return nil, false, fmt.Errorf("failed to convert the status belonging to component [%s] to map[string]interface{}, while removing error [%s]", componentRdeSectionName, errorName)
+	}
+	componentStatus, err := convertMapToComponentStatus(componentMap)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to convert component status map to Component object")
+	}
+
+	// remove errors from the errorSet Map
+	// if vcdResourceId is empty, remove all the errors matching the errorName, else remove the errors matching both the
+	// errorName and vcdResourceId
+	matchingErrorsRemoved := false
+	for i := 0; i < len(componentStatus.ErrorSet); i++ {
+		if (vcdResourceId == "" && componentStatus.ErrorSet[i].Name == errorName) ||
+			(vcdResourceId != "" && componentStatus.ErrorSet[i].Name == errorName && componentStatus.ErrorSet[i].VcdResourceId == vcdResourceId) {
+			componentStatus.ErrorSet = append(componentStatus.ErrorSet[:i], componentStatus.ErrorSet[i+1:]...)
+			i--
+			matchingErrorsRemoved = true
+		}
+	}
+	componentMap[ComponentStatusFieldErrorSet] = componentStatus.ErrorSet
+	return statusMap, matchingErrorsRemoved, nil
 }

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/defined_entity_util.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/defined_entity_util.go
@@ -14,11 +14,11 @@ func (e CapvcdRdeFoundError) Error() string {
 }
 
 type CPIStatus struct {
-	Name           string               `json:"name,omitempty"`
+	Name           string        `json:"name,omitempty"`
 	Version        string        `json:"version,omitempty"`
 	VCDResourceSet []VCDResource `json:"vcdResourceSet,omitempty"`
 	Errors         []string      `json:"errors,omitempty"`
-	VirtualIPs     []string             `json:"virtualIPs,omitempty"`
+	VirtualIPs     []string      `json:"virtualIPs,omitempty"`
 }
 
 func GetVirtualIPsFromRDE(rde *swaggerClient.DefinedEntity) ([]string, error) {

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/gateway.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/gateway.go
@@ -1502,7 +1502,6 @@ func (gm *GatewayManager) CreateLoadBalancer(ctx context.Context, virtualService
 		}
 		resourcesAllocated.Insert(VcdResourceLoadBalancerPool, lbPoolRef)
 
-
 		virtualServiceRef, err := gm.CreateVirtualService(ctx, virtualServiceName, lbPoolRef, segRef,
 			virtualServiceIP, portDetails.Protocol, portDetails.ExternalPort,
 			portDetails.UseSSL, portDetails.CertAlias)

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/ipam.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/ipam.go
@@ -16,7 +16,7 @@ import (
 
 type IPRange struct {
 	StartIP string
-	EndIP string
+	EndIP   string
 }
 
 // GetUnusedExternalIPAddress returns the first unused IP address in the gateway from an ipamSubnet
@@ -57,7 +57,7 @@ func (gm *GatewayManager) GetUnusedExternalIPAddress(ctx context.Context, allowe
 			for _, ipRangeValue := range subnet.IpRanges.Values {
 				ipRangeList = append(ipRangeList, IPRange{
 					StartIP: ipRangeValue.StartAddress,
-					EndIP: ipRangeValue.EndAddress,
+					EndIP:   ipRangeValue.EndAddress,
 				})
 			}
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -67,7 +67,7 @@ github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/thecodeteam/gofsutil v0.1.2
 ## explicit
-# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220529190526-5ecf051bba6a
+# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220601204501-2f50e812a02b
 ## explicit; go 1.17
 github.com/vmware/cloud-provider-for-cloud-director/pkg/util
 github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk


### PR DESCRIPTION
* Updated the latest common code base in CPI
* set Default Window Size as 10 for both errors and events.
* Implement errors and events according to [doc](https://confluence.eng.vmware.com/display/VCD/Possible+CSI+errors+and+events)
* All the errors can't be removed if `re-operate successfully` except `RdeIncorrectFormalError`
* Tested Errors and Events by placing different images.