### PR TITLE
VCDA-4014: make CSI point to 1.3.0-beta. Also remove `.latest` suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ build-within-docker:
 	go build -ldflags "-X github.com/vmware/cloud-director-named-disk-csi-driver/version.Version=$(version)" -o /build/vcloud/cloud-director-named-disk-csi-driver cmd/csi/main.go
 
 csi: $(GO_CODE)
-	docker build -f Dockerfile . -t cloud-director-named-disk-csi-driver:$(version).latest
-	docker tag cloud-director-named-disk-csi-driver:$(version).latest $(REGISTRY)/cloud-director-named-disk-csi-driver:$(version).latest
-	# docker tag cloud-director-named-disk-csi-driver:$(version).latest $(REGISTRY)/cloud-director-named-disk-csi-driver:$(version).$$(docker images cloud-director-named-disk-csi-driver:$(version).latest -q)
-	docker push $(REGISTRY)/cloud-director-named-disk-csi-driver:$(version).latest
+	docker build -f Dockerfile . -t cloud-director-named-disk-csi-driver:$(version)
+	docker tag cloud-director-named-disk-csi-driver:$(version) $(REGISTRY)/cloud-director-named-disk-csi-driver:$(version)
+	# docker tag cloud-director-named-disk-csi-driver:$(version) $(REGISTRY)/cloud-director-named-disk-csi-driver:$(version).$$(docker images cloud-director-named-disk-csi-driver:$(version) -q)
+	docker push $(REGISTRY)/cloud-director-named-disk-csi-driver:$(version)
 	touch out/$@
 
 all: csi

--- a/manifests/csi-controller.yaml
+++ b/manifests/csi-controller.yaml
@@ -139,7 +139,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: harbor-repo.vmware.com/vcloud/cloud-director-named-disk-csi-driver:vkp-branch.latest
+          image: projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.3.0-beta
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-director-named-disk-csi-driver

--- a/manifests/csi-node.yaml
+++ b/manifests/csi-node.yaml
@@ -77,7 +77,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: harbor-repo.vmware.com/vcloud/cloud-director-named-disk-csi-driver:vkp-branch.latest
+          image: projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.3.0-beta
           imagePullPolicy: IfNotPresent
           command :
             - /opt/vcloud/bin/cloud-director-named-disk-csi-driver

--- a/release/version
+++ b/release/version
@@ -1,1 +1,1 @@
-vkp-branch
+1.3.0-beta


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-director-named-disk-csi-driver/73)
<!-- Reviewable:end -->
