### PR TITLE
[VCDA-4178] Add wire logging to CSI containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ COPY --from=builder /go/src/github.com/vmware/cloud-director-named-disk-csi-driv
 COPY --from=builder /build/vcloud/cloud-director-named-disk-csi-driver .
 
 RUN chmod +x /opt/vcloud/bin/cloud-director-named-disk-csi-driver
+RUN mkdir /opt/vcloud/logs
+RUN touch /opt/vcloud/logs/csi-wire-log.txt
+RUN chmod 666 /opt/vcloud/logs/csi-wire-log.txt
 
 # USER nobody
 ENTRYPOINT ["/bin/bash", "-l", "-c"]

--- a/manifests/csi-controller-crs.yaml
+++ b/manifests/csi-controller-crs.yaml
@@ -160,6 +160,10 @@ spec:
                 secretKeyRef:
                   name: vcloud-clusterid-secret
                   key: clusterid
+            - name: GOVCD_LOG
+              value: "true"
+            - name: GOVCD_LOG_FILE
+              value: "/opt/vcloud/logs/csi-wire-log.txt"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/manifests/csi-controller.yaml
+++ b/manifests/csi-controller.yaml
@@ -155,6 +155,10 @@ spec:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: GOVCD_LOG
+              value: "true"
+            - name: GOVCD_LOG_FILE
+              value: "/opt/vcloud/logs/csi-wire-log.txt"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/manifests/csi-node-crs.yaml
+++ b/manifests/csi-node-crs.yaml
@@ -97,6 +97,10 @@ spec:
                 secretKeyRef:
                   name: vcloud-clusterid-secret
                   key: clusterid
+            - name: GOVCD_LOG
+              value: "true"
+            - name: GOVCD_LOG_FILE
+              value: "/opt/vcloud/logs/cpi-wire-log.txt"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/manifests/csi-node-crs.yaml
+++ b/manifests/csi-node-crs.yaml
@@ -100,7 +100,7 @@ spec:
             - name: GOVCD_LOG
               value: "true"
             - name: GOVCD_LOG_FILE
-              value: "/opt/vcloud/logs/cpi-wire-log.txt"
+              value: "/opt/vcloud/logs/csi-wire-log.txt"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/manifests/csi-node.yaml
+++ b/manifests/csi-node.yaml
@@ -92,6 +92,10 @@ spec:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
+            - name: GOVCD_LOG
+              value: "true"
+            - name: GOVCD_LOG_FILE
+              value: "/opt/vcloud/logs/cpi-wire-log.txt"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/manifests/csi-node.yaml
+++ b/manifests/csi-node.yaml
@@ -95,7 +95,7 @@ spec:
             - name: GOVCD_LOG
               value: "true"
             - name: GOVCD_LOG_FILE
-              value: "/opt/vcloud/logs/cpi-wire-log.txt"
+              value: "/opt/vcloud/logs/csi-wire-log.txt"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi


### PR DESCRIPTION
* Set environment variables in the manifests to enable wire logging 
* Dockerfile changes to grant permissions to write to the wire log file

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-director-named-disk-csi-driver/82)
<!-- Reviewable:end -->
