### PR TITLE
VCDA-4225: Build internal images for 1.3.z and point to image

### DIFF
--- a/manifests/csi-controller-crs.yaml
+++ b/manifests/csi-controller-crs.yaml
@@ -140,7 +140,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: harbor-repo.vmware.com/vcloud/cloud-director-named-disk-csi-driver:main-branch.f98ae03
+          image: harbor-repo.vmware.com/vcloud/cloud-director-named-disk-csi-driver:1.3.z.359681c
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-director-named-disk-csi-driver

--- a/manifests/csi-controller.yaml
+++ b/manifests/csi-controller.yaml
@@ -140,7 +140,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: harbor-repo.vmware.com/vcloud/cloud-director-named-disk-csi-driver:main-branch.f98ae03
+          image: harbor-repo.vmware.com/vcloud/cloud-director-named-disk-csi-driver:1.3.z.359681c
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-director-named-disk-csi-driver

--- a/manifests/csi-node-crs.yaml
+++ b/manifests/csi-node-crs.yaml
@@ -77,7 +77,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: harbor-repo.vmware.com/vcloud/cloud-director-named-disk-csi-driver:main-branch.f98ae03
+          image: harbor-repo.vmware.com/vcloud/cloud-director-named-disk-csi-driver:1.3.z.359681c
           imagePullPolicy: IfNotPresent
           command :
             - /opt/vcloud/bin/cloud-director-named-disk-csi-driver

--- a/manifests/csi-node.yaml
+++ b/manifests/csi-node.yaml
@@ -77,7 +77,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: harbor-repo.vmware.com/vcloud/cloud-director-named-disk-csi-driver:main-branch.f98ae03
+          image: harbor-repo.vmware.com/vcloud/cloud-director-named-disk-csi-driver:1.3.z.359681c
           imagePullPolicy: IfNotPresent
           command :
             - /opt/vcloud/bin/cloud-director-named-disk-csi-driver


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-director-named-disk-csi-driver/97)
<!-- Reviewable:end -->
