### PR TITLE
[VKC-78] Use registry.k8s.io to replace k8s.gcr.io (#151)

### DIFF
--- a/manifests/csi-controller-crs.yaml
+++ b/manifests/csi-controller-crs.yaml
@@ -108,7 +108,7 @@ spec:
       dnsPolicy: Default
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.2.1
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -121,7 +121,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+          image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)

--- a/manifests/csi-controller-crs.yaml.template
+++ b/manifests/csi-controller-crs.yaml.template
@@ -108,7 +108,7 @@ spec:
       dnsPolicy: Default
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.2.1
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -121,7 +121,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+          image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)

--- a/manifests/csi-controller.yaml
+++ b/manifests/csi-controller.yaml
@@ -108,7 +108,7 @@ spec:
       dnsPolicy: Default
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.2.1
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -121,7 +121,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+          image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)

--- a/manifests/csi-controller.yaml.template
+++ b/manifests/csi-controller.yaml.template
@@ -108,7 +108,7 @@ spec:
       dnsPolicy: Default
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.2.1
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -121,7 +121,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+          image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)

--- a/manifests/csi-node-crs.yaml
+++ b/manifests/csi-node-crs.yaml
@@ -47,7 +47,7 @@ spec:
       dnsPolicy: Default
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
           imagePullPolicy: "IfNotPresent"
           args:
             - "--v=5"

--- a/manifests/csi-node-crs.yaml.template
+++ b/manifests/csi-node-crs.yaml.template
@@ -47,7 +47,7 @@ spec:
       dnsPolicy: Default
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
           imagePullPolicy: "IfNotPresent"
           args:
             - "--v=5"

--- a/manifests/csi-node.yaml
+++ b/manifests/csi-node.yaml
@@ -47,7 +47,7 @@ spec:
       dnsPolicy: Default
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+          image:registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
           imagePullPolicy: "IfNotPresent"
           args:
             - "--v=5"

--- a/manifests/csi-node.yaml.template
+++ b/manifests/csi-node.yaml.template
@@ -47,7 +47,7 @@ spec:
       dnsPolicy: Default
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
           imagePullPolicy: "IfNotPresent"
           args:
             - "--v=5"


### PR DESCRIPTION
Signed-off-by: ymo24 <ymo@vmware.com>
(cherry picked from commit a233d5a457e982c4bbcd3efc49c63359cf7eb6e1)

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Use registry.k8s.io to replace k8s.gcr.io

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## Testing Done
Please provide a screenshot of the testing results for the code change in this Pull Request. Verify that this pull request's code change will not affect CSI's normal operation


## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-director-named-disk-csi-driver/154)
<!-- Reviewable:end -->
