### PR TITLE
[VKC-79] Use registry.k8s.io to replace k8s.gcr.io

### DIFF
--- a/manifests/csi-controller.yaml
+++ b/manifests/csi-controller.yaml
@@ -124,7 +124,6 @@ spec:
           image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
           imagePullPolicy: IfNotPresent
           args:
-            -
             - --csi-address=$(ADDRESS)
             - --timeout=300s
             - --v=5

--- a/manifests/csi-controller.yaml
+++ b/manifests/csi-controller.yaml
@@ -108,7 +108,7 @@ spec:
       dnsPolicy: Default
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.2.1
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -121,9 +121,10 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+          image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
           imagePullPolicy: IfNotPresent
           args:
+            -
             - --csi-address=$(ADDRESS)
             - --timeout=300s
             - --v=5

--- a/manifests/csi-node.yaml
+++ b/manifests/csi-node.yaml
@@ -47,7 +47,7 @@ spec:
       dnsPolicy: Default
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
           imagePullPolicy: "IfNotPresent"
           args:
             - "--v=5"


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Use registry.k8s.io to replace k8s.gcr.io

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## Testing Done
Please provide a screenshot of the testing results for the code change in this Pull Request. Verify that this pull request's code change will not affect CSI's normal operation


## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-director-named-disk-csi-driver/155)
<!-- Reviewable:end -->
