### PR TITLE
Allow customization of driver name

### DIFF
--- a/cmd/csi/main.go
+++ b/cmd/csi/main.go
@@ -8,13 +8,14 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/vmware/cloud-director-named-disk-csi-driver/pkg/config"
 	"github.com/vmware/cloud-director-named-disk-csi-driver/pkg/csi"
 	"github.com/vmware/cloud-director-named-disk-csi-driver/pkg/vcdcsiclient"
 	"github.com/vmware/cloud-director-named-disk-csi-driver/version"
 	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
-	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -23,6 +24,7 @@ import (
 )
 
 var (
+	driverName      string
 	endpointFlag    string
 	nodeIDFlag      string
 	cloudConfigFlag string
@@ -70,6 +72,7 @@ func main() {
 
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 
+	cmd.PersistentFlags().StringVar(&driverName, "driver-name", "named-disk.csi.cloud-director.vmware.com", "driver name")
 	cmd.PersistentFlags().StringVar(&nodeIDFlag, "nodeid", "", "node id")
 
 	// add this flag to distinguish between node plugin and csi controller. Ensure RDE upgrade only happens in csi controller
@@ -92,8 +95,7 @@ func main() {
 }
 
 func runCommand() {
-
-	d, err := csi.NewDriver(nodeIDFlag, endpointFlag)
+	d, err := csi.NewDriver(driverName, nodeIDFlag, endpointFlag)
 	if err != nil {
 		panic(fmt.Errorf("unable to create new driver: [%v]", err))
 	}

--- a/pkg/csi/driver.go
+++ b/pkg/csi/driver.go
@@ -8,12 +8,13 @@ package csi
 import (
 	"context"
 	"fmt"
+	"net"
+	"os"
+
 	"github.com/vmware/cloud-director-named-disk-csi-driver/pkg/util"
 	"github.com/vmware/cloud-director-named-disk-csi-driver/pkg/vcdcsiclient"
 	"github.com/vmware/cloud-director-named-disk-csi-driver/version"
 	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
-	"net"
-	"os"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc"
@@ -52,12 +53,12 @@ var (
 )
 
 // NewDriver creates new VCDDriver
-func NewDriver(nodeID string, endpoint string) (*VCDDriver, error) {
+func NewDriver(name string, nodeID string, endpoint string) (*VCDDriver, error) {
 
-	klog.Infof("Driver: [%s] Version: [%s]", Name, version.Version)
+	klog.Infof("Driver: [%s] Version: [%s]", name, version.Version)
 
 	d := &VCDDriver{
-		name:     Name,
+		name:     name,
 		nodeID:   nodeID,
 		version:  version.Version,
 		endpoint: endpoint,

--- a/pkg/csi/identity.go
+++ b/pkg/csi/identity.go
@@ -1,21 +1,17 @@
 /*
-    Copyright 2021 VMware, Inc.
-    SPDX-License-Identifier: Apache-2.0
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
 */
 
 package csi
 
 import (
 	"context"
+
 	"github.com/vmware/cloud-director-named-disk-csi-driver/version"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"k8s.io/klog"
-)
-
-const (
-	// Name is the name of this CSI plugin.
-	Name = "named-disk.csi.cloud-director.vmware.com"
 )
 
 type identityServer struct {
@@ -37,7 +33,7 @@ func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*c
 func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 	klog.Infof("GetPluginInfo: called with args [%+v]", *req)
 	resp := &csi.GetPluginInfoResponse{
-		Name:          Name,
+		Name:          ids.Driver.name,
 		VendorVersion: version.Version,
 	}
 


### PR DESCRIPTION
## Description
Adds new flag `driver-name` to main, to allow users to customize the driver and change its default from *"named-disk.csi.cloud-director.vmware.com"* to another value.

The intention is that this way there could be multiple instances/deployments of [cloud-director-named-disk-csi-driver](https://github.com/vmware/cloud-director-named-disk-csi-driver) deployed on the same Kubernetes cluster but with different CSIDriver names (and storage classes), configured for multiple different VDC's which host Kubernetes nodes.

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples
