### PR TITLE
[VKC-129] Cherry-pick: Update CSI system tests – use correct userOrg for xfs tests, skip StorageProfile test if not sysadmin

### DIFF
--- a/tests/e2e/storageProfile_test.go
+++ b/tests/e2e/storageProfile_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/vmware/cloud-director-named-disk-csi-driver/tests/utils"
@@ -37,6 +38,12 @@ var _ = Describe("CSI Storage Profile Test", func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(tc).NotTo(BeNil())
 	Expect(&tc.Cs).NotTo(BeNil())
+
+	BeforeEach(func() {
+		if !tc.VcdClient.VCDAuthConfig.IsSysAdmin {
+			Skip(fmt.Sprintf("Skipping StorageProfile tests as StorageProfile tests are expected to be ran by sysadmin and [%s:%s] is not a sysadmin user", userName, userOrg))
+		}
+	})
 
 	It("should find the storage profile", func() {
 		By("ensuring that admin org exists")

--- a/tests/e2e/xfs_fsType_test.go
+++ b/tests/e2e/xfs_fsType_test.go
@@ -27,7 +27,7 @@ var _ = Describe("CSI dynamic provisioning Test", func() {
 		OrgName:      org,
 		Username:     userName,
 		RefreshToken: refreshToken,
-		UserOrg:      "system",
+		UserOrg:      userOrg,
 		GetVdcClient: true,
 	}, rdeId)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
…, skip StorageProfile tests if not sysadmin (#206)

Signed-off-by: lzichong <lzichong@vmware.com>
(cherry picked from commit 073ffc8d8937bebbc60f884bc689ee6a5229e03e)

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Cherrypick commit 073ffc8d8937bebbc60f884bc689ee6a5229e03e

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## Testing Done
Please provide a screenshot of the testing results for the code change in this Pull Request. Verify that this pull request's code change will not affect CSI's normal operation


## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-director-named-disk-csi-driver/208)
<!-- Reviewable:end -->
