### PR TITLE
[VKC-135] Refactor CSI tests to be more resilient

### DIFF
--- a/tests/e2e/dynamic_provisioning_test.go
+++ b/tests/e2e/dynamic_provisioning_test.go
@@ -106,7 +106,7 @@ var _ = Describe("CSI dynamic provisioning Test", func() {
 			},
 			ContainerParams: testingsdk.ContainerParams{
 				ContainerName:  "nginx",
-				ContainerImage: "nginx:1.14.2",
+				ContainerImage: "projects-stg.registry.vmware.com/vmware-cloud-director/nginx:1.14.2",
 				ContainerPort:  80,
 			},
 			VolumeParams: testingsdk.VolumeParams{
@@ -230,6 +230,7 @@ var _ = Describe("CSI dynamic provisioning Test", func() {
 
 	//scenario 2: use 'Delete' retention policy. step2: install a deployment using the above PVC.
 	It("Should create Deployment using delete reclaim policy", func() {
+		By("Creating a deployment with delete policy in storage class")
 		deployment, err := tc.CreateDeployment(ctx, &testingsdk.DeployParams{
 			Name: testDeploymentName,
 			Labels: map[string]string{
@@ -237,7 +238,7 @@ var _ = Describe("CSI dynamic provisioning Test", func() {
 			},
 			ContainerParams: testingsdk.ContainerParams{
 				ContainerName:  "nginx",
-				ContainerImage: "nginx:1.14.2",
+				ContainerImage: "projects-stg.registry.vmware.com/vmware-cloud-director/nginx:1.14.2",
 				ContainerPort:  80,
 			},
 			VolumeParams: testingsdk.VolumeParams{
@@ -248,12 +249,14 @@ var _ = Describe("CSI dynamic provisioning Test", func() {
 		}, testNameSpaceName)
 		Expect(deployment).NotTo(BeNil())
 		Expect(err).NotTo(HaveOccurred())
+
+		By("PVC status should be 'bound'")
 		err = utils.WaitForPvcReady(ctx, tc.Cs.(*kubernetes.Clientset), testNameSpaceName, testDeletePVCName)
 		Expect(err).NotTo(HaveOccurred())
-		By("PVC status should be 'bound'")
+
+		By("Deployment should be ready")
 		err = tc.WaitForDeploymentReady(ctx, testNameSpaceName, testDeletePVCName)
 		Expect(err).NotTo(HaveOccurred())
-		By("Deployment should be ready")
 	})
 
 	//scenario 2: use 'Delete' retention policy. step3: verify the PV is not presented after PVC deleted.

--- a/tests/e2e/dynamic_provisioning_test.go
+++ b/tests/e2e/dynamic_provisioning_test.go
@@ -105,7 +105,9 @@ var _ = Describe("CSI dynamic provisioning Test", func() {
 				"app": testDeploymentName,
 			},
 			ContainerParams: testingsdk.ContainerParams{
-				ContainerName:  "nginx",
+				ContainerName: "nginx",
+				// When running the tests locally, projects-stg may be unavailable outside of VMware.
+				// Please use nginx:1.14.2 as the ContainerImage if projects-stg is unavailable or giving ImagePullBackoffError.
 				ContainerImage: "projects-stg.registry.vmware.com/vmware-cloud-director/nginx:1.14.2",
 				ContainerPort:  80,
 			},
@@ -237,7 +239,9 @@ var _ = Describe("CSI dynamic provisioning Test", func() {
 				"app": testDeploymentName,
 			},
 			ContainerParams: testingsdk.ContainerParams{
-				ContainerName:  "nginx",
+				ContainerName: "nginx",
+				// When running the tests locally, projects-stg may be unavailable outside of VMware.
+				// Please use nginx:1.14.2 as the ContainerImage if projects-stg is unavailable or giving ImagePullBackoffError.
 				ContainerImage: "projects-stg.registry.vmware.com/vmware-cloud-director/nginx:1.14.2",
 				ContainerPort:  80,
 			},

--- a/tests/e2e/static_provisioning_test.go
+++ b/tests/e2e/static_provisioning_test.go
@@ -88,7 +88,9 @@ var _ = Describe("CSI static provisioning Test", func() {
 				"app": "nginx",
 			},
 			ContainerParams: testingsdk.ContainerParams{
-				ContainerName:  "nginx",
+				ContainerName: "nginx",
+				// When running the tests locally, projects-stg may be unavailable outside of VMware.
+				// Please use nginx:1.14.2 as the ContainerImage if projects-stg is unavailable or giving ImagePullBackoffError.
 				ContainerImage: "projects-stg.registry.vmware.com/vmware-cloud-director/nginx:1.14.2",
 				ContainerPort:  80,
 			},
@@ -175,7 +177,9 @@ var _ = Describe("CSI static provisioning Test", func() {
 				"app": "nginx",
 			},
 			ContainerParams: testingsdk.ContainerParams{
-				ContainerName:  "nginx",
+				ContainerName: "nginx",
+				// When running the tests locally, projects-stg may be unavailable outside of VMware.
+				// Please use nginx:1.14.2 as the ContainerImage if projects-stg is unavailable or giving ImagePullBackoffError.
 				ContainerImage: "projects-stg.registry.vmware.com/vmware-cloud-director/nginx:1.14.2",
 				ContainerPort:  80,
 			},

--- a/tests/e2e/xfs_fsType_test.go
+++ b/tests/e2e/xfs_fsType_test.go
@@ -88,7 +88,7 @@ var _ = Describe("CSI dynamic provisioning Test", func() {
 			},
 			ContainerParams: testingsdk.ContainerParams{
 				ContainerName:  "nginx",
-				ContainerImage: "nginx:1.14.2",
+				ContainerImage: "projects-stg.registry.vmware.com/vmware-cloud-director/nginx:1.14.2",
 				ContainerPort:  80,
 			},
 			VolumeParams: testingsdk.VolumeParams{

--- a/tests/e2e/xfs_fsType_test.go
+++ b/tests/e2e/xfs_fsType_test.go
@@ -87,7 +87,9 @@ var _ = Describe("CSI dynamic provisioning Test", func() {
 				"app": testDeploymentName,
 			},
 			ContainerParams: testingsdk.ContainerParams{
-				ContainerName:  "nginx",
+				ContainerName: "nginx",
+				// When running the tests locally, projects-stg may be unavailable outside of VMware.
+				// Please use nginx:1.14.2 as the ContainerImage if projects-stg is unavailable or giving ImagePullBackoffError.
 				ContainerImage: "projects-stg.registry.vmware.com/vmware-cloud-director/nginx:1.14.2",
 				ContainerPort:  80,
 			},

--- a/tests/utils/kubernetes_ops_util.go
+++ b/tests/utils/kubernetes_ops_util.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	defaultLongRetryInterval = 20 * time.Second
-	defaultLongRetryTimeout  = 300 * time.Second
+	defaultLongRetryTimeout  = 600 * time.Second
 )
 
 // ExecCmdExample ExecCmd exec command on specific pod and wait the command's output.


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Refactor CSI tests to be more resilient
  - Update PV orderings, as there could be race conditions due to randomized tests where a PV can be deleted by PVC, but delete with code also.
  - Update containerImage to use staging to prevent API rate limitings in public docker
  - Increase CSI specific timeouts
  - Update `GetPVByNameViaRDE()` to return the expected error if field is missing

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## Testing Done
Please provide a screenshot of the testing results for the code change in this Pull Request. Verify that this pull request's code change will not affect CSI's normal operation


## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-director-named-disk-csi-driver/213)
<!-- Reviewable:end -->
