### PR TITLE
Fix CSI test for air-gapped env

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -21,7 +21,7 @@ var (
 )
 
 const (
-	airgappedImage = "core.harbor.10.89.98.101.nip.io/airgapped/nginx:1.14.2"
+	airgappedImage = "harbor.10.221.134.246.nip.io/airgapped/nginx:1.14.2"
 	stagingImage   = "projects-stg.registry.vmware.com/vmware-cloud-director/nginx:1.14.2"
 )
 


### PR DESCRIPTION
## Description
During merge of cse-2-24-next branch into main, the private registry info in e2e test was overwritten to an old private registry. This PR reverts the change related to private registry in e2e tests.

- 

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## Testing Done
Please provide a screenshot of the testing results for the code change in this Pull Request. Verify that this pull request's code change will not affect CSI's normal operation


## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-director-named-disk-csi-driver/239)
<!-- Reviewable:end -->
