### PR TITLE
[VCDA-6991] Update dependency and bom template to use vmware-cloud-director as image paths

### DIFF
--- a/artifacts/bom.json.template
+++ b/artifacts/bom.json.template
@@ -17,7 +17,7 @@
 		"binaries": [],
 		"dependencies": [
 			{
-				"name":"cloud-director-named-disk-csi-driver",
+				"name":"vmware-cloud-director/cloud-director-named-disk-csi-driver",
 				"version":"__VERSION__",
 				"imageRepository":"__REGISTRY__"
 			},{

--- a/artifacts/dependencies.txt.template
+++ b/artifacts/dependencies.txt.template
@@ -1,4 +1,4 @@
-__REGISTRY__ cloud-director-named-disk-csi-driver __VERSION__
+__REGISTRY__ vmware-cloud-director/cloud-director-named-disk-csi-driver __VERSION__
 registry.k8s.io sig-storage/csi-node-driver-registrar v2.2.0
 registry.k8s.io sig-storage/csi-attacher v3.2.1
 registry.k8s.io sig-storage/csi-provisioner v2.2.2


### PR DESCRIPTION

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Updates bom.json.template and dependencies.txt.template to use 'vmware-cloud-director/*' for consistency

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## Testing Done
Please provide a screenshot of the testing results for the code change in this Pull Request. Verify that this pull request's code change will not affect CSI's normal operation


## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-director-named-disk-csi-driver/253)
<!-- Reviewable:end -->
