### PR TITLE
[VKC-194] Revert makefile and registry changes to behavior from 1.5.z

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ CSI_IMG := cloud-director-named-disk-csi-driver
 ARTIFACT_IMG := csi-crs-airgapped
 VERSION ?= $(shell cat $(GITROOT)/release/version)
 
+REGISTRY ?= projects-stg.registry.vmware.com/vmware-cloud-director
+
 PLATFORM ?= linux/amd64
 OS ?= linux
 ARCH ?= amd64
@@ -111,7 +113,7 @@ docker-build-csi: manifests build
 	docker build  \
 		--platform $(PLATFORM) \
 		--file Dockerfile \
-		--tag $(CSI_IMG):$(VERSION) \
+		--tag $(REGISTRY)/$(CSI_IMG):$(VERSION) \
 		--build-arg CSI_BUILD_DIR=bin \
 		.
 
@@ -120,7 +122,7 @@ docker-build-artifacts: release-prep
 	docker build  \
 		--platform $(PLATFORM) \
 		--file artifacts/Dockerfile \
-		--tag $(ARTIFACT_IMG):$(VERSION) \
+		--tag $(REGISTRY)/$(ARTIFACT_IMG):$(VERSION) \
 		.
 
 .PHONY: docker-build
@@ -180,8 +182,8 @@ release: docker-build docker-push ## Build release images and push to registry.
 release-prep:  ## Generate BOM and dependencies files.
 	sed -e "s/__VERSION__/$(VERSION)/g"  artifacts/default-csi-controller-crs-airgap.yaml.template > artifacts/csi-controller-crs-airgap.yaml.template
 	sed -e "s/__VERSION__/$(VERSION)/g"  artifacts/default-csi-node-crs-airgap.yaml.template > artifacts/csi-node-crs-airgap.yaml.template
-	sed -e "s/__VERSION__/$(VERSION)/g"  artifacts/bom.json.template > artifacts/bom.json
-	sed -e "s/__VERSION__/$(VERSION)/g"  artifacts/dependencies.txt.template > artifacts/dependencies.txt
+	sed -e "s/__VERSION__/$(VERSION)/g"  -e "s~__REGISTRY__~$(REGISTRY)~g" artifacts/bom.json.template > artifacts/bom.json
+	sed -e "s/__VERSION__/$(VERSION)/g"  -e "s~__REGISTRY__~$(REGISTRY)~g" artifacts/dependencies.txt.template > artifacts/dependencies.txt
 
 .PHONY: manifests
 manifests: ## Generate CSI manifests
@@ -195,25 +197,23 @@ gcr-csi:
 	docker pull registry.k8s.io/sig-storage/csi-node-driver-registrar:$(CSI_NODE_DRIVER_REGISTRAR_VERSION)
 	docker pull registry.k8s.io/sig-storage/csi-attacher:$(CSI_ATTACHER_VERSION)
 	docker pull registry.k8s.io/sig-storage/csi-provisioner:$(CSI_PROVISIONER_VERSION)
-	docker tag registry.k8s.io/sig-storage/csi-node-driver-registrar:$(CSI_NODE_DRIVER_REGISTRAR_VERSION) projects-stg.registry.vmware.com/vmware-cloud-director/sig-storage/csi-node-driver-registrar:$(CSI_NODE_DRIVER_REGISTRAR_VERSION)
-	docker tag registry.k8s.io/sig-storage/csi-attacher:$(CSI_ATTACHER_VERSION) projects-stg.registry.vmware.com/vmware-cloud-director/sig-storage/csi-attacher:$(CSI_ATTACHER_VERSION)
-	docker tag registry.k8s.io/sig-storage/csi-provisioner:$(CSI_PROVISIONER_VERSION) projects-stg.registry.vmware.com/vmware-cloud-director/sig-storage/csi-provisioner:$(CSI_PROVISIONER_VERSION)
+	docker tag registry.k8s.io/sig-storage/csi-node-driver-registrar:$(CSI_NODE_DRIVER_REGISTRAR_VERSION) $(REGISTRY)/sig-storage/csi-node-driver-registrar:$(CSI_NODE_DRIVER_REGISTRAR_VERSION)
+	docker tag registry.k8s.io/sig-storage/csi-attacher:$(CSI_ATTACHER_VERSION) $(REGISTRY)/sig-storage/csi-attacher:$(CSI_ATTACHER_VERSION)
+	docker tag registry.k8s.io/sig-storage/csi-provisioner:$(CSI_PROVISIONER_VERSION) $(REGISTRY)/sig-storage/csi-provisioner:$(CSI_PROVISIONER_VERSION)
 
 .PHONY: docker-push-csi
 docker-push-csi: # Push CSI image to registry.
-	docker tag $(CSI_IMG)/$(VERSION) projects-stg.registry.vmware.com/vmware-cloud-director/$(CSI_IMG):$(VERSION)
-	docker push projects-stg.registry.vmware.com/vmware-cloud-director/$(CSI_IMG):$(VERSION)
+	docker push $(REGISTRY)/$(CSI_IMG):$(VERSION)
 
 .PHONY: docker-push-artifacts
 docker-push-artifacts: # Push artifacts image to registry
-	docker tag $(ARTIFACT_IMG):$(VERSION) projects-stg.registry.vmware.com/vmware-cloud-director/$(ARTIFACT_IMG):$(VERSION)
-	docker push projects-stg.registry.vmware.com/vmware-cloud-director/$(ARTIFACT_IMG):$(VERSION)
+	docker push $(REGISTRY)/$(ARTIFACT_IMG):$(VERSION)
 
 .PHONY: docker-push-gcr-csi
 docker-push-gcr-csi: gcr-csi ## Publish GCR images to container registry.
-	docker push projects-stg.registry.vmware.com/vmware-cloud-director/sig-storage/csi-node-driver-registrar:$(CSI_NODE_DRIVER_REGISTRAR_VERSION)
-	docker push projects-stg.registry.vmware.com/vmware-cloud-director/sig-storage/csi-attacher:$(CSI_ATTACHER_VERSION)
-	docker push projects-stg.registry.vmware.com/vmware-cloud-director/sig-storage/csi-provisioner:$(CSI_PROVISIONER_VERSION)
+	docker push $(REGISTRY)/sig-storage/csi-node-driver-registrar:$(CSI_NODE_DRIVER_REGISTRAR_VERSION)
+	docker push $(REGISTRY)/sig-storage/csi-attacher:$(CSI_ATTACHER_VERSION)
+	docker push $(REGISTRY)/sig-storage/csi-provisioner:$(CSI_PROVISIONER_VERSION)
 
 .PHONY: docker-push
 docker-push: docker-push-csi docker-push-artifacts docker-push-gcr-csi ## Push images to container registry.

--- a/artifacts/bom.json.template
+++ b/artifacts/bom.json.template
@@ -17,7 +17,7 @@
 		"binaries": [],
 		"dependencies": [
 			{
-				"name":"vmware-cloud-director/cloud-director-named-disk-csi-driver",
+				"name":"cloud-director-named-disk-csi-driver",
 				"version":"__VERSION__",
 				"imageRepository":"__REGISTRY__"
 			},{

--- a/artifacts/dependencies.txt.template
+++ b/artifacts/dependencies.txt.template
@@ -1,4 +1,4 @@
-__REGISTRY__ vmware-cloud-director/cloud-director-named-disk-csi-driver __VERSION__
+__REGISTRY__ cloud-director-named-disk-csi-driver __VERSION__
 registry.k8s.io sig-storage/csi-node-driver-registrar v2.2.0
 registry.k8s.io sig-storage/csi-attacher v3.2.1
 registry.k8s.io sig-storage/csi-provisioner v2.2.2


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Reverts the behavior of 1.6.z builds back to 1.5.z

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## Testing Done
Please provide a screenshot of the testing results for the code change in this Pull Request. Verify that this pull request's code change will not affect CSI's normal operation


## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-director-named-disk-csi-driver/261)
<!-- Reviewable:end -->
