### PR TITLE
[VKC-212] Fix CSI volume expansion test, parameterize defaultStorageClassProfile

### DIFF
--- a/tests/e2e/dynamic_provisioning_test.go
+++ b/tests/e2e/dynamic_provisioning_test.go
@@ -132,8 +132,6 @@ var _ = Describe("CSI dynamic provisioning Test", func() {
 	})
 
 	//scenario 1: use 'Retain' retention policy. step4: expand volume (ONLINE Expansion).
-	// ONLINE expansion is expected to fail when name disk storage profile name does not match up with VM storage profile names.
-	// Bugzilla ID: 3366176
 	It("should ONLINE EXPAND above PVC since volumeExpansion is enabled", func() {
 		By("should expand a PVC successfully")
 		pvc, err := utils.IncreasePVCSize(ctx, tc.Cs.(*kubernetes.Clientset), testNameSpaceName, testRetainPVCName,
@@ -144,6 +142,7 @@ var _ = Describe("CSI dynamic provisioning Test", func() {
 
 		By("PVC size should be updated")
 		// If the StorageClass storage profile name created is different from the cluster VM's storage profile name, csi-resizer may complain of VCD error.
+		// Bugzilla ID: 3366176
 		err = utils.WaitForPvcSizeUpdated(ctx, tc.Cs.(*kubernetes.Clientset), testNameSpaceName, testRetainPVCName,
 			resource.MustParse("4Gi"))
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/dynamic_provisioning_test.go
+++ b/tests/e2e/dynamic_provisioning_test.go
@@ -15,17 +15,16 @@ import (
 )
 
 const (
-	testNameSpaceName     = "provisioning-test-ns"
-	testRetainPVCName     = "test-retain-pvc"
-	testDeletePVCName     = "test-delete-pvc"
-	testDeploymentName    = "test-deployment"
-	storageClassDelete    = "delete-storage-class"
-	storageClassRetain    = "retain-storage-class"
-	storageClassXfs       = "xfs-storage-class"
-	storageClassExt4      = "ext4"
-	storageSize           = "2Gi"
-	defaultStorageProfile = "*"
-	volumeName            = "deployment-pv"
+	testNameSpaceName  = "provisioning-test-ns"
+	testRetainPVCName  = "test-retain-pvc"
+	testDeletePVCName  = "test-delete-pvc"
+	testDeploymentName = "test-deployment"
+	storageClassDelete = "delete-storage-class"
+	storageClassRetain = "retain-storage-class"
+	storageClassXfs    = "xfs-storage-class"
+	storageClassExt4   = "ext4"
+	storageSize        = "2Gi"
+	volumeName         = "deployment-pv"
 
 	ONEGIG = 1 << 30
 )
@@ -142,6 +141,7 @@ var _ = Describe("CSI dynamic provisioning Test", func() {
 		fmt.Printf("PVC [%s/%s] updated size is [%v]\n", testNameSpaceName, testRetainPVCName, pvc.Spec.Resources.Requests.Storage())
 
 		By("PVC size should be updated")
+		// If the StorageClass storage profile name created is different from the cluster VM's storage profile name, csi-resizer may complain of VCD error.
 		err = utils.WaitForPvcSizeUpdated(ctx, tc.Cs.(*kubernetes.Clientset), testNameSpaceName, testRetainPVCName,
 			resource.MustParse("4Gi"))
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/dynamic_provisioning_test.go
+++ b/tests/e2e/dynamic_provisioning_test.go
@@ -132,6 +132,8 @@ var _ = Describe("CSI dynamic provisioning Test", func() {
 	})
 
 	//scenario 1: use 'Retain' retention policy. step4: expand volume (ONLINE Expansion).
+	// ONLINE expansion is expected to fail when name disk storage profile name does not match up with VM storage profile names.
+	// Bugzilla ID: 3366176
 	It("should ONLINE EXPAND above PVC since volumeExpansion is enabled", func() {
 		By("should expand a PVC successfully")
 		pvc, err := utils.IncreasePVCSize(ctx, tc.Cs.(*kubernetes.Clientset), testNameSpaceName, testRetainPVCName,

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -16,6 +16,8 @@ var (
 	userName     string
 	userOrg      string
 	refreshToken string
+	// defaultStorageProfile is parameterized due to possible VCD issue from different VM (cluster) / Named Disk storage profile names
+	defaultStorageProfile string
 
 	ContainerImage string
 )
@@ -34,6 +36,7 @@ func init() {
 	flag.StringVar(&userName, "userName", "", "Username for login to generate client")
 	flag.StringVar(&refreshToken, "refreshToken", "", "Refresh token of user to generate client")
 	flag.StringVar(&rdeId, "rdeId", "", "Cluster ID to fetch cluster RDE")
+	flag.StringVar(&defaultStorageProfile, "defaultStorageProfile", "*", "Default storage profile to create PVC and StorageClass")
 }
 
 var _ = BeforeSuite(func() {

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -17,7 +17,7 @@ var (
 	userOrg      string
 	refreshToken string
 	// defaultStorageProfile is parameterized due to possible VCD issue from different VM (cluster) / Named Disk storage profile names
-	defaultStorageProfile string
+	defaultStorageProfile string // Could be "*" or "Development2"
 
 	ContainerImage string
 )

--- a/tests/utils/kubernetes_ops_util.go
+++ b/tests/utils/kubernetes_ops_util.go
@@ -117,8 +117,8 @@ func WaitForPvcSizeUpdated(ctx context.Context, k8sClient *kubernetes.Clientset,
 			return false, nil
 		}
 
-		fmt.Printf("PVC [%s/%s] size is [%v]\n", nameSpace, pvcName, pvc.Spec.Resources.Requests.Storage())
-		if pvc.Spec.Resources.Requests.Storage().Cmp(newSize) == 0 {
+		fmt.Printf("Current PVC [%s/%s] size is [%v], expected: [%v]\n", nameSpace, pvcName, pvc.Status.Capacity.Storage(), newSize.String())
+		if pvc.Status.Capacity.Storage().Cmp(newSize) == 0 {
 			return true, nil
 		}
 


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Fix CSI volume expansion test, parameterize defaultStorageClassProfi

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## Testing Done
Please provide a screenshot of the testing results for the code change in this Pull Request. Verify that this pull request's code change will not affect CSI's normal operation

Ran 22 of 25 Specs in 546.607 seconds
SUCCESS! -- 22 Passed | 0 Failed | 0 Pending | 3 Skipped
--- PASS: TestCSIAutomation (569.62s)
PASS

Skipped tests are from xfs_fsType_test.go due to being a tenant user.

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-director-named-disk-csi-driver/269)
<!-- Reviewable:end -->
